### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,76 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+.env
+
+# Unit test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.cache
+coverage.xml
+*.cover
+
+# Tooling
+.ruff_cache/
+.mypy_cache/
+.dmypy.json
+.ipynb_checkpoints/
+
+# IDEs / editors
+.idea/
+.vscode/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# ---- Project-specific ----
+# Trained model checkpoints
+*.pt
+*.pth
+*.ckpt
+checkpoints/
+runs/
+logs/
+wandb/
+
+# Generated / downloaded datasets (kept out of VCS; small samples live under data/samples)
+*.csv
+!data/samples/*.csv
+data/raw/
+data/cache/
+*.smi
+*.sdf


### PR DESCRIPTION
Adds a comprehensive .gitignore. The repo previously tracked nothing, so Python bytecode, virtualenvs, tooling caches, trained checkpoints (*.pt/*.pth), and generated/downloaded datasets would all be committed by accident. Keeps a carve-out for small sample datasets under data/samples/.