### PR TITLE
Adopt ruff for linting and formatting

### DIFF
--- a/molgen/generate.py
+++ b/molgen/generate.py
@@ -1,11 +1,22 @@
-import torch
-from rdkit import Chem
-import torch.nn.functional as F
 import warnings
-from rdkit import RDLogger
+
+import torch
+import torch.nn.functional as F
+from rdkit import Chem, RDLogger
+
 from molgen.vae import BetaTCVAE, SimpleTokenizer
 
-def generate_nearby_smiles(model_path, smiles, tokenizer, max_len, num_samples, device, temperature=1.0, distance_multiplier=0.5):
+
+def generate_nearby_smiles(
+    model_path,
+    smiles,
+    tokenizer,
+    max_len,
+    num_samples,
+    device,
+    temperature=1.0,
+    distance_multiplier=0.5,
+):
     """
     Generate nearby SMILES strings by perturbing the latent space representation.
 
@@ -20,7 +31,7 @@ def generate_nearby_smiles(model_path, smiles, tokenizer, max_len, num_samples, 
         distance_multiplier (float): Multiplier to adjust the distance in latent space.
 
     Returns:
-        list of str: List of generated SMILES strings. 
+        list of str: List of generated SMILES strings.
     """
     # Load the model
     vocab_size = 6
@@ -30,9 +41,11 @@ def generate_nearby_smiles(model_path, smiles, tokenizer, max_len, num_samples, 
     nhead = 4
     num_layers = 2
     pad_idx = 4
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    model = BetaTCVAE(vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device).to(device)
+    model = BetaTCVAE(
+        vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
+    ).to(device)
     model.load_state_dict(torch.load(model_path))
     model.eval()
 
@@ -40,7 +53,6 @@ def generate_nearby_smiles(model_path, smiles, tokenizer, max_len, num_samples, 
     embedded = model.embedding(tokenized_smiles)
     encoded = model.encoder(embedded)
     mu = model.mu(encoded)
-    log_var = model.log_var(encoded)
 
     generated_smiles = []
     for i in range(num_samples):
@@ -53,12 +65,17 @@ def generate_nearby_smiles(model_path, smiles, tokenizer, max_len, num_samples, 
         out = F.softmax(out / temperature, dim=-1)
 
         generated_smiles_idx = torch.multinomial(out.squeeze(0), 1).cpu().numpy().flatten()
-        generated_smiles_str = ''.join(
-            [tokenizer.idx_to_char[min(int(idx), 4)] for idx in generated_smiles_idx if idx != tokenizer.pad_idx])
+        generated_smiles_str = "".join(
+            [
+                tokenizer.idx_to_char[min(int(idx), 4)]
+                for idx in generated_smiles_idx
+                if idx != tokenizer.pad_idx
+            ]
+        )
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            RDLogger.DisableLog('rdApp.*')
+            RDLogger.DisableLog("rdApp.*")
             mol = Chem.MolFromSmiles(generated_smiles_str)
 
         if mol is not None:
@@ -69,19 +86,28 @@ def generate_nearby_smiles(model_path, smiles, tokenizer, max_len, num_samples, 
 
 def main():
     # Example usage
-    input_smiles = 'OC(CCCCCC)C(O)C(O)C(O)CCCCCCCCC'
+    input_smiles = "OC(CCCCCC)C(O)C(O)C(O)CCCCCCCCC"
     num_samples = 5000
     max_len = 172  # Set to the maximum sequence length used during training
     temperature = 2.0
     distance_multiplier = 0.5
-    model_path = 'beta_tc_vae_model.pth'
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model_path = "beta_tc_vae_model.pth"
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     simple_tokenizer = SimpleTokenizer()
-    generated_smiles = generate_nearby_smiles(model_path, input_smiles, simple_tokenizer, max_len, num_samples, device, temperature, distance_multiplier)
+    generated_smiles = generate_nearby_smiles(
+        model_path,
+        input_smiles,
+        simple_tokenizer,
+        max_len,
+        num_samples,
+        device,
+        temperature,
+        distance_multiplier,
+    )
 
     print(f"Input SMILES: {input_smiles}")
-    print(f"Generated SMILES:")
+    print("Generated SMILES:")
     for smiles in generated_smiles:
         print(smiles)
 

--- a/molgen/interpolate.py
+++ b/molgen/interpolate.py
@@ -1,12 +1,15 @@
-import torch
-from rdkit import Chem
-import torch.nn.functional as F
 import warnings
-from rdkit import RDLogger
+
+import torch
+import torch.nn.functional as F
+from rdkit import Chem, RDLogger
+
 from molgen.vae import BetaTCVAE, SimpleTokenizer
 
 
-def interpolate_smiles(model_path, smiles_1, smiles_2, tokenizer, max_len, device, num_steps=5, temperature=1.0):
+def interpolate_smiles(
+    model_path, smiles_1, smiles_2, tokenizer, max_len, device, num_steps=5, temperature=1.0
+):
     """
     Interpolate between two SMILES strings in the latent space.
 
@@ -21,7 +24,7 @@ def interpolate_smiles(model_path, smiles_1, smiles_2, tokenizer, max_len, devic
         temperature (float): Temperature for sampling.
 
     Returns:
-        list of str: List of interpolated SMILES strings. 
+        list of str: List of interpolated SMILES strings.
     """
     # Load the model
     vocab_size = 6
@@ -31,9 +34,11 @@ def interpolate_smiles(model_path, smiles_1, smiles_2, tokenizer, max_len, devic
     nhead = 4
     num_layers = 2
     pad_idx = 4
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    model = BetaTCVAE(vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device).to(device)
+    model = BetaTCVAE(
+        vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
+    ).to(device)
     model.load_state_dict(torch.load(model_path))
     model.eval()
 
@@ -59,12 +64,17 @@ def interpolate_smiles(model_path, smiles_1, smiles_2, tokenizer, max_len, devic
         out = F.softmax(out / temperature, dim=-1)
 
         generated_smiles_idx = torch.multinomial(out.squeeze(0), 1).cpu().numpy().flatten()
-        generated_smiles_str = ''.join(
-            [tokenizer.idx_to_char[min(int(idx), 4)] for idx in generated_smiles_idx if idx != tokenizer.pad_idx])
+        generated_smiles_str = "".join(
+            [
+                tokenizer.idx_to_char[min(int(idx), 4)]
+                for idx in generated_smiles_idx
+                if idx != tokenizer.pad_idx
+            ]
+        )
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            RDLogger.DisableLog('rdApp.*')
+            RDLogger.DisableLog("rdApp.*")
             mol = Chem.MolFromSmiles(generated_smiles_str)
 
         if mol is not None:
@@ -75,21 +85,29 @@ def interpolate_smiles(model_path, smiles_1, smiles_2, tokenizer, max_len, devic
 
 def main():
     # Example usage
-    input_smiles = 'OC(CCCCCC)C(O)C(O)C(O)CCCCCCCCC'
-    input_smiles_2 = 'OCC(O)C(O)C(O)C(CCCC)CCCCCCCC'
+    input_smiles = "OC(CCCCCC)C(O)C(O)C(O)CCCCCCCCC"
+    input_smiles_2 = "OCC(O)C(O)C(O)C(CCCC)CCCCCCCC"
     num_steps = 5000
     max_len = 172  # Set to the maximum sequence length used during training
     temperature = 1.5
-    model_path = 'beta_tc_vae_model.pth'
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model_path = "beta_tc_vae_model.pth"
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     simple_tokenizer = SimpleTokenizer()
-    interpolated_smiles = interpolate_smiles(model_path, input_smiles, input_smiles_2, simple_tokenizer, max_len,
-                                             device, num_steps, temperature)
+    interpolated_smiles = interpolate_smiles(
+        model_path,
+        input_smiles,
+        input_smiles_2,
+        simple_tokenizer,
+        max_len,
+        device,
+        num_steps,
+        temperature,
+    )
 
     print(f"Input SMILES: {input_smiles}")
     print(f"Input SMILES: {input_smiles_2}")
-    print(f"Generated SMILES:")
+    print("Generated SMILES:")
     for smiles in interpolated_smiles:
         print(smiles)
 

--- a/molgen/synthetic.py
+++ b/molgen/synthetic.py
@@ -1,7 +1,7 @@
-import random
 import csv
+import random
+
 from rdkit import Chem
-from rdkit.Chem import Descriptors
 
 
 def consecutive_hydroxyls(chain):
@@ -9,7 +9,7 @@ def consecutive_hydroxyls(chain):
     Check if the chain contains five or more consecutive hydroxyl groups.
 
     Args:
-        chain (list of str): The carbon chain with possible hydroxyl groups. 
+        chain (list of str): The carbon chain with possible hydroxyl groups.
 
     Returns:
         bool: True if there are five or more consecutive hydroxyl groups, False otherwise.
@@ -18,10 +18,10 @@ def consecutive_hydroxyls(chain):
     max_count = 0
     i = 0
     while i < len(chain) - 1:
-        if chain[i] == 'C' and chain[i + 1] == '(':
+        if chain[i] == "C" and chain[i + 1] == "(":
             count += 1
             max_count = max(max_count, count)
-        elif chain[i] == 'C' and chain[i + 1] == 'C':
+        elif chain[i] == "C" and chain[i + 1] == "C":
             count = 0
         i += 1
     return max_count >= 5
@@ -40,13 +40,13 @@ def generate_molecule(min_carbon, max_carbon):
     """
     while True:
         num_carbon = random.randint(min_carbon, max_carbon)
-        carbon_chain = ['C' for _ in range(num_carbon)]
+        carbon_chain = ["C" for _ in range(num_carbon)]
 
         # Randomly generate hydroxyl groups
         num_hydroxyl = random.randint(1, num_carbon)
         hydroxyl_positions = random.sample(range(num_carbon), num_hydroxyl)
         for pos in hydroxyl_positions:
-            carbon_chain[pos] += '(O)'
+            carbon_chain[pos] += "(O)"
 
         if consecutive_hydroxyls(carbon_chain):
             continue
@@ -56,10 +56,10 @@ def generate_molecule(min_carbon, max_carbon):
         branch_positions = random.sample(range(num_carbon), num_branches)
         for pos in branch_positions:
             branch_length = random.randint(1, 10)
-            branch = 'C' * branch_length
-            carbon_chain[pos] += '(' + branch + ')'
+            branch = "C" * branch_length
+            carbon_chain[pos] += "(" + branch + ")"
 
-        smiles = ''.join(carbon_chain)
+        smiles = "".join(carbon_chain)
         mol = Chem.MolFromSmiles(smiles)
         if mol is not None:
             return smiles
@@ -73,14 +73,14 @@ def save_molecules_to_csv(filename, molecules):
         filename (str): The name of the CSV file.
         molecules (list of str): The list of SMILES strings.
     """
-    with open(filename, 'w', newline='', encoding='utf-8') as csvfile:
+    with open(filename, "w", newline="", encoding="utf-8") as csvfile:
         csv_writer = csv.writer(csvfile)
-        csv_writer.writerow(['SMILES'])  # Write the header
+        csv_writer.writerow(["SMILES"])  # Write the header
 
         for smiles in molecules:
             csv_writer.writerow([smiles])  # Write each row
 
-    print(f'Successfully saved {len(molecules)} generated molecules to {filename}')
+    print(f"Successfully saved {len(molecules)} generated molecules to {filename}")
 
 
 def main():
@@ -95,7 +95,7 @@ def main():
     generated_molecules = list(set(generated_molecules))
 
     # Save the generated molecules to a CSV file
-    save_molecules_to_csv('molecules.csv', generated_molecules)
+    save_molecules_to_csv("molecules.csv", generated_molecules)
 
 
 if __name__ == "__main__":

--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -1,11 +1,10 @@
 import pandas as pd
 import torch
-from rdkit import Chem
-from torch.utils.data import Dataset, DataLoader
-from sklearn.model_selection import train_test_split
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from sklearn.model_selection import train_test_split
+from torch.utils.data import DataLoader, Dataset
 
 
 class SMILESDataset(Dataset):
@@ -27,7 +26,9 @@ class SMILESDataset(Dataset):
         return tokenized_smiles
 
 
-def smiles_data_loader(csv_file, tokenizer, batch_size, max_len=None, test_split=0.2, shuffle=True, num_workers=0):
+def smiles_data_loader(
+    csv_file, tokenizer, batch_size, max_len=None, test_split=0.2, shuffle=True, num_workers=0
+):
     """
     Load SMILES data from a CSV file, tokenize it, and split into train and test sets.
 
@@ -45,7 +46,7 @@ def smiles_data_loader(csv_file, tokenizer, batch_size, max_len=None, test_split
         test_loader (DataLoader): DataLoader for the test set.
     """
     data = pd.read_csv(csv_file)
-    smiles_list = data['SMILES'].tolist()
+    smiles_list = data["SMILES"].tolist()
 
     if max_len is None:
         max_len = max(len(smiles) for smiles in smiles_list)
@@ -54,17 +55,21 @@ def smiles_data_loader(csv_file, tokenizer, batch_size, max_len=None, test_split
     train_dataset = SMILESDataset(train_smiles, tokenizer, max_len)
     test_dataset = SMILESDataset(test_smiles, tokenizer, max_len)
 
-    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle, num_workers=num_workers)
-    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=shuffle, num_workers=num_workers)
+    train_loader = DataLoader(
+        train_dataset, batch_size=batch_size, shuffle=shuffle, num_workers=num_workers
+    )
+    test_loader = DataLoader(
+        test_dataset, batch_size=batch_size, shuffle=shuffle, num_workers=num_workers
+    )
 
     return train_loader, test_loader
 
 
 class SimpleTokenizer:
     def __init__(self):
-        self.char_to_idx = {'C': 0, 'O': 1, '(': 2, ')': 3, '<pad>': 4}
+        self.char_to_idx = {"C": 0, "O": 1, "(": 2, ")": 3, "<pad>": 4}
         self.idx_to_char = {v: k for k, v in self.char_to_idx.items()}
-        self.pad_idx = self.char_to_idx['<pad>']
+        self.pad_idx = self.char_to_idx["<pad>"]
 
     def tokenize(self, smiles, max_len):
         """
@@ -83,19 +88,21 @@ class SimpleTokenizer:
 
 
 class BetaTCVAE(nn.Module):
-    def __init__(self, vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device):
+    def __init__(
+        self, vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
+    ):
         super(BetaTCVAE, self).__init__()
 
         self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=pad_idx)
         self.encoder = nn.TransformerEncoder(
-            nn.TransformerEncoderLayer(embedding_dim, nhead, hidden_dim),
-            num_layers=num_layers)
+            nn.TransformerEncoderLayer(embedding_dim, nhead, hidden_dim), num_layers=num_layers
+        )
         self.mu = nn.Linear(embedding_dim, latent_dim)
         self.log_var = nn.Linear(embedding_dim, latent_dim)
 
         self.decoder = nn.TransformerDecoder(
-            nn.TransformerDecoderLayer(embedding_dim, nhead, hidden_dim),
-            num_layers=num_layers)
+            nn.TransformerDecoderLayer(embedding_dim, nhead, hidden_dim), num_layers=num_layers
+        )
         self.fc_out = nn.Linear(embedding_dim, vocab_size)
 
         self.device = device
@@ -119,7 +126,7 @@ class BetaTCVAE(nn.Module):
 
 
 def loss_function(recon_x, x, mu, log_var, beta, gamma):
-    BCE = F.cross_entropy(recon_x.view(-1, recon_x.size(-1)), x.view(-1), reduction='mean')
+    BCE = F.cross_entropy(recon_x.view(-1, recon_x.size(-1)), x.view(-1), reduction="mean")
     KLD = -0.5 * torch.mean(1 + log_var - mu.pow(2) - log_var.exp())
     TC = (log_var.exp() - 1 - log_var).mean()
 
@@ -169,11 +176,13 @@ def test(model, test_loader, device, beta, gamma):
 
 def main():
     simple_tokenizer = SimpleTokenizer()
-    csv_file = 'molecules.csv'
+    csv_file = "molecules.csv"
     batch_size = 64
     max_len = None  # Can be set to a specific value, or let the function calculate
 
-    train_loader, test_loader = smiles_data_loader(csv_file, simple_tokenizer.tokenize, batch_size, max_len)
+    train_loader, test_loader = smiles_data_loader(
+        csv_file, simple_tokenizer.tokenize, batch_size, max_len
+    )
 
     # Hyperparameters
     vocab_size = 6  # Set according to the actual vocabulary size
@@ -183,10 +192,12 @@ def main():
     nhead = 4
     num_layers = 2
     pad_idx = 4  # Set according to the actual padding index
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # Create the model
-    model = BetaTCVAE(vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device).to(device)
+    model = BetaTCVAE(
+        vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
+    ).to(device)
 
     # Optimizer
     optimizer = optim.Adam(model.parameters(), lr=0.001)
@@ -204,7 +215,7 @@ def main():
         print(f"Test Loss: {test_loss:.4f}, Test Accuracy: {test_accuracy:.4f}")
 
     # Save the model
-    torch.save(model.state_dict(), 'beta_tc_vae_model.pth')
+    torch.save(model.state_dict(), "beta_tc_vae_model.pth")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,13 @@ Issues = "https://github.com/DaoyuanLi2816/Molecule-Generator/issues"
 
 [tool.setuptools.packages.find]
 include = ["molgen*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
Introduces ruff as the linter/formatter and applies it across the codebase.

**Config** (in `pyproject.toml`): line length 100, rule set E/F/I/W, double-quote formatting, target py39.

**Auto-applied fixes**
- Sorted/organized import blocks across all modules.
- Removed unused imports (`rdkit.Chem` in `vae.py`, `rdkit.Chem.Descriptors` in `synthetic.py`) and a dead `log_var` computation in `generate.py`.
- Removed redundant f-string prefixes (`f"Generated SMILES:"`) and trailing whitespace.
- Reflowed lines exceeding the 100-char limit.

**Validation**: `ruff check` and `ruff format --check` both pass; all modules still import cleanly.
