### PR TITLE
Add pytest smoke test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,7 @@ select = ["E", "F", "I", "W"]
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,16 @@
+"""Smoke tests for the molgen package itself."""
+
+import molgen
+
+
+def test_version_is_nonempty_string():
+    assert isinstance(molgen.__version__, str)
+    assert molgen.__version__
+
+
+def test_submodules_import():
+    # Importing must be free of side effects (no dataset generation, etc.).
+    import molgen.generate  # noqa: F401
+    import molgen.interpolate  # noqa: F401
+    import molgen.synthetic  # noqa: F401
+    import molgen.vae  # noqa: F401

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,0 +1,31 @@
+"""Tests for the synthetic dataset generator."""
+
+import random
+
+from rdkit import Chem
+
+from molgen.synthetic import generate_molecule
+
+
+def test_generated_molecules_are_valid():
+    random.seed(0)
+    for _ in range(50):
+        smiles = generate_molecule(min_carbon=5, max_carbon=12)
+        assert Chem.MolFromSmiles(smiles) is not None, smiles
+
+
+def test_backbone_respects_minimum_carbons():
+    random.seed(1)
+    smiles = generate_molecule(min_carbon=8, max_carbon=8)
+    mol = Chem.MolFromSmiles(smiles)
+    n_carbons = sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "C")
+    # 8-carbon backbone plus optional branches -> at least 8 carbons.
+    assert n_carbons >= 8
+
+
+def test_generation_is_reproducible_with_seed():
+    random.seed(123)
+    first = generate_molecule(min_carbon=6, max_carbon=10)
+    random.seed(123)
+    second = generate_molecule(min_carbon=6, max_carbon=10)
+    assert first == second

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,29 @@
+"""Tests for the SimpleTokenizer."""
+
+import torch
+
+from molgen.vae import SimpleTokenizer
+
+
+def test_tokenize_shape_and_dtype():
+    tok = SimpleTokenizer()
+    out = tok.tokenize("CCO", max_len=10)
+    assert isinstance(out, torch.Tensor)
+    assert out.dtype == torch.long
+    assert out.shape == (10,)
+
+
+def test_tokenize_pads_with_pad_idx():
+    tok = SimpleTokenizer()
+    out = tok.tokenize("CC", max_len=5)
+    assert out[0].item() == tok.char_to_idx["C"]
+    assert out[1].item() == tok.char_to_idx["C"]
+    assert bool((out[2:] == tok.pad_idx).all())
+
+
+def test_tokenize_decode_roundtrip():
+    tok = SimpleTokenizer()
+    smiles = "C(O)CC"
+    out = tok.tokenize(smiles, max_len=len(smiles))
+    decoded = "".join(tok.idx_to_char[int(i)] for i in out)
+    assert decoded == smiles

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -1,0 +1,47 @@
+"""Tests for the BetaTCVAE model and loss."""
+
+import torch
+
+from molgen.vae import BetaTCVAE, loss_function
+
+
+def _tiny_model():
+    return BetaTCVAE(
+        vocab_size=6,
+        embedding_dim=16,
+        hidden_dim=64,
+        latent_dim=16,
+        nhead=4,
+        num_layers=2,
+        pad_idx=4,
+        device=torch.device("cpu"),
+    )
+
+
+def test_forward_output_shapes():
+    model = _tiny_model()
+    batch, seq = 4, 12
+    x = torch.randint(0, 6, (batch, seq))
+    out, mu, log_var = model(x)
+    assert out.shape == (batch, seq, 6)
+    assert mu.shape == (batch, seq, 16)
+    assert log_var.shape == (batch, seq, 16)
+
+
+def test_loss_is_finite_scalar():
+    model = _tiny_model()
+    x = torch.randint(0, 6, (4, 12))
+    out, mu, log_var = model(x)
+    loss = loss_function(out, x, mu, log_var, beta=1.0, gamma=0.1)
+    assert loss.dim() == 0
+    assert torch.isfinite(loss)
+
+
+def test_backward_pass_populates_gradients():
+    model = _tiny_model()
+    x = torch.randint(0, 6, (2, 8))
+    out, mu, log_var = model(x)
+    loss = loss_function(out, x, mu, log_var, beta=1.0, gamma=0.1)
+    loss.backward()
+    grads = [p.grad for p in model.parameters() if p.requires_grad]
+    assert any(g is not None and torch.isfinite(g).all() for g in grads)


### PR DESCRIPTION
Adds the first automated tests so CI has something to run.

**Coverage**
- `test_package.py`: version string present; all submodules import without side effects.
- `test_synthetic.py`: generated molecules are RDKit-valid, the backbone respects the minimum carbon count, and generation is reproducible under a fixed seed.
- `test_tokenizer.py`: `SimpleTokenizer` output shape/dtype, padding behaviour, and decode round-trip.
- `test_vae.py`: `BetaTCVAE` forward output shapes, finite scalar loss, and a backward pass that populates gradients.

Configures pytest via `pyproject.toml` (`testpaths = ["tests"]`).

**Validation**: `ruff check` clean; `pytest` → 11 passed.
