### PR TITLE
Add GitHub Actions CI (lint + tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: lint & test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install CPU PyTorch
+        # Use the CPU wheel index to avoid pulling large CUDA dependencies on CI.
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package (with dev extras)
+        run: pip install -e ".[dev]"
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
Adds a continuous integration workflow that runs on pushes to `main` and on pull requests.

**Matrix**: Python 3.10 / 3.11 / 3.12 on `ubuntu-latest`.

**Steps**: install CPU-only PyTorch (avoids pulling large CUDA wheels on CI), `pip install -e ".[dev]"`, then `ruff check`, `ruff format --check`, and `pytest`.

GPU-dependent validation is run locally; CI covers linting, formatting, and CPU smoke tests. Adds a `concurrency` group so superseded runs on the same ref are cancelled.
