### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Run `pre-commit install` once to enable these hooks locally.
+# They mirror the checks enforced in CI (.github/workflows/ci.yml).
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 selfies = ["selfies>=2.1"]
-dev = ["pytest>=7.0", "ruff>=0.4"]
+dev = ["pytest>=7.0", "ruff>=0.4", "pre-commit>=3.5"]
 
 [project.urls]
 Homepage = "https://github.com/DaoyuanLi2816/Molecule-Generator"


### PR DESCRIPTION
Adds a pre-commit configuration so contributors catch the same issues CI enforces, before pushing.

**Hooks**
- `ruff` (with `--fix`) and `ruff-format` — same linter/formatter CI runs.
- `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-toml`, `check-added-large-files`, `mixed-line-ending` (`--fix=lf`, consistent with `.gitattributes`).

`pre-commit` is added to the `dev` optional-dependency group; enable with `pre-commit install`.

**Validation**: config parses as valid YAML; `ruff check` clean; `pytest` → 11 passed.
