### PR TITLE
Add contributing guide and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report a problem with molgen
+title: ""
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+A minimal code snippet or the steps that trigger the problem:
+
+```python
+# ...
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- molgen version:
+- Python version:
+- OS:
+- PyTorch / RDKit versions:
+
+**Additional context**
+Add any other context, tracebacks, or screenshots here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ""
+labels: enhancement
+---
+
+**Is your feature request related to a problem?**
+A clear and concise description of the problem or limitation.
+
+**Describe the solution you'd like**
+What you would like to happen.
+
+**Alternatives considered**
+Any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or references (papers, repos) here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123. Delete if not applicable. -->
+
+## How was this tested?
+
+<!-- Commands run, datasets/models used, observed results. -->
+
+## Checklist
+
+- [ ] `ruff check .` passes
+- [ ] `ruff format --check .` passes
+- [ ] `pytest` passes
+- [ ] Added/updated tests where appropriate
+- [ ] Updated documentation if behaviour changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Molecule-Generator
+
+Thanks for your interest in improving this project! Contributions of all kinds
+are welcome — bug reports, fixes, new models, metrics, and documentation.
+
+## Development setup
+
+```bash
+git clone https://github.com/DaoyuanLi2816/Molecule-Generator.git
+cd Molecule-Generator
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+pre-commit install
+```
+
+This installs `molgen` in editable mode with the development tools (ruff,
+pytest, pre-commit). RDKit is pulled in automatically; see the
+[RDKit install guide](https://www.rdkit.org/docs/Install.html) if you hit
+platform-specific issues.
+
+## Running checks locally
+
+```bash
+ruff check .            # lint
+ruff format .           # auto-format
+pytest                  # run the test suite
+```
+
+The pre-commit hooks run the lint/format checks automatically on `git commit`.
+CI (`.github/workflows/ci.yml`) runs the same checks on Python 3.10–3.12.
+
+## Submitting changes
+
+1. Create a topic branch off `main` (e.g. `fix/loss-padding-mask`).
+2. Make your change and add tests where it makes sense.
+3. Ensure `ruff check .`, `ruff format --check .`, and `pytest` all pass.
+4. Open a pull request describing **what** changed and **why**, and how you
+   verified it.
+
+## Code style
+
+- Formatted and linted with [ruff](https://docs.astral.sh/ruff/) (line length 100).
+- Prefer small, focused pull requests with a clear single purpose.
+- Keep public functions documented with concise docstrings.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+project's [MIT License](LICENSE).


### PR DESCRIPTION
Adds community-health files so contributors have clear guidance (the README invites PRs but there was no `CONTRIBUTING.md` or templates).

**Added**
- `CONTRIBUTING.md`: development setup (`pip install -e ".[dev]"`, `pre-commit install`), how to run lint/format/tests, the branch → PR workflow, and code-style notes.
- `.github/PULL_REQUEST_TEMPLATE.md`: summary / related issues / testing / checklist.
- `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`.

Docs/templates only — no code changes; `ruff` and `pytest` remain green.
