### PR TITLE
Add reproducibility, device, and logging utilities

### DIFF
--- a/molgen/utils.py
+++ b/molgen/utils.py
@@ -1,0 +1,52 @@
+"""Shared utilities: reproducibility, device selection, and logging."""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+
+import numpy as np
+import torch
+
+__all__ = ["set_seed", "get_device", "get_logger"]
+
+
+def set_seed(seed: int, deterministic: bool = False) -> None:
+    """Seed the Python, NumPy, and PyTorch RNGs for reproducible runs.
+
+    Args:
+        seed: The random seed to apply to all RNGs.
+        deterministic: If True, also request deterministic cuDNN/cuBLAS
+            behaviour. This is slower but makes GPU runs reproducible.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    if deterministic:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        # Required for deterministic cuBLAS matmuls on CUDA >= 10.2.
+        os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+
+
+def get_device(prefer_cuda: bool = True) -> torch.device:
+    """Return the best available torch device (CUDA if present, else CPU)."""
+    if prefer_cuda and torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def get_logger(name: str = "molgen", level: int = logging.INFO) -> logging.Logger:
+    """Return a configured logger that attaches a single stderr handler."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        logger.addHandler(handler)
+        logger.setLevel(level)
+        logger.propagate = False
+    return logger

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+"""Tests for the shared utilities."""
+
+import random
+
+import numpy as np
+import torch
+
+from molgen.utils import get_device, get_logger, set_seed
+
+
+def test_set_seed_makes_python_reproducible():
+    set_seed(42)
+    a = [random.random() for _ in range(5)]
+    set_seed(42)
+    b = [random.random() for _ in range(5)]
+    assert a == b
+
+
+def test_set_seed_makes_numpy_and_torch_reproducible():
+    set_seed(7)
+    na, ta = np.random.rand(4), torch.rand(4)
+    set_seed(7)
+    nb, tb = np.random.rand(4), torch.rand(4)
+    assert np.allclose(na, nb)
+    assert torch.allclose(ta, tb)
+
+
+def test_get_device_returns_torch_device():
+    dev = get_device()
+    assert isinstance(dev, torch.device)
+    assert dev.type in {"cuda", "cpu"}
+
+
+def test_get_logger_attaches_single_handler():
+    log1 = get_logger("molgen.test")
+    log2 = get_logger("molgen.test")
+    assert log1 is log2
+    assert len(log1.handlers) == 1


### PR DESCRIPTION
Adds a small `molgen.utils` module with reproducibility, device, and logging helpers. The existing code had no seeding (runs were non-reproducible) and used bare `print` statements.

**Added**
- `set_seed(seed, deterministic=False)` — seeds Python / NumPy / PyTorch (incl. CUDA); optional deterministic cuDNN/cuBLAS for fully reproducible GPU runs.
- `get_device(prefer_cuda=True)` — returns the best available `torch.device`.
- `get_logger(name, level)` — returns a logger with a single stderr handler (idempotent).

**Tests** (`tests/test_utils.py`): seed reproducibility for Python/NumPy/PyTorch RNGs, device type, and single-handler logger behaviour.

**Validation**: `ruff check` clean; `pytest` → 15 passed.
