### PR TITLE
Respect the device argument in generate and interpolate

### DIFF
--- a/molgen/generate.py
+++ b/molgen/generate.py
@@ -41,7 +41,6 @@ def generate_nearby_smiles(
     nhead = 4
     num_layers = 2
     pad_idx = 4
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     model = BetaTCVAE(
         vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device

--- a/molgen/interpolate.py
+++ b/molgen/interpolate.py
@@ -34,7 +34,6 @@ def interpolate_smiles(
     nhead = 4
     num_layers = 2
     pad_idx = 4
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     model = BetaTCVAE(
         vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,59 @@
+"""Integration tests for the generate / interpolate entry points."""
+
+import torch
+from rdkit import Chem
+
+from molgen.generate import generate_nearby_smiles
+from molgen.interpolate import interpolate_smiles
+from molgen.vae import BetaTCVAE, SimpleTokenizer
+
+
+def _save_tiny_model(path):
+    # Architecture must match the hyperparameters hardcoded in generate/interpolate.
+    model = BetaTCVAE(
+        vocab_size=6,
+        embedding_dim=16,
+        hidden_dim=64,
+        latent_dim=16,
+        nhead=4,
+        num_layers=2,
+        pad_idx=4,
+        device=torch.device("cpu"),
+    )
+    torch.save(model.state_dict(), path)
+
+
+def test_generate_nearby_smiles_runs_on_explicit_device(tmp_path):
+    ckpt = tmp_path / "model.pth"
+    _save_tiny_model(ckpt)
+    out = generate_nearby_smiles(
+        str(ckpt),
+        "CCO",
+        SimpleTokenizer(),
+        max_len=12,
+        num_samples=5,
+        device=torch.device("cpu"),
+        temperature=1.0,
+    )
+    assert isinstance(out, list)
+    # The function only returns RDKit-parseable SMILES.
+    for smi in out:
+        assert Chem.MolFromSmiles(smi) is not None
+
+
+def test_interpolate_smiles_runs_on_explicit_device(tmp_path):
+    ckpt = tmp_path / "model.pth"
+    _save_tiny_model(ckpt)
+    out = interpolate_smiles(
+        str(ckpt),
+        "CCO",
+        "CCCO",
+        SimpleTokenizer(),
+        max_len=12,
+        device=torch.device("cpu"),
+        num_steps=5,
+        temperature=1.0,
+    )
+    assert isinstance(out, list)
+    for smi in out:
+        assert Chem.MolFromSmiles(smi) is not None


### PR DESCRIPTION
Fixes a correctness bug where the `device` argument was ignored.

**Bug**: both `generate_nearby_smiles` and `interpolate_smiles` declare a `device` parameter, then immediately do `device = torch.device("cuda" if torch.cuda.is_available() else "cpu")` — silently discarding whatever the caller passed (e.g. a specific GPU, or a forced CPU run).

**Fix**: remove the override so the supplied `device` is used for the model, inputs, and sampling.

**Tests**: adds `tests/test_generate.py`, which builds a tiny matching checkpoint and runs both entry points end-to-end on an explicit device — these functions had no test coverage before. Verified on CPU (CI) and on a CUDA device locally.

**Validation**: `ruff check` clean; `pytest` → 17 passed.
