### PR TITLE
Load checkpoints safely with map_location and weights_only

### DIFF
--- a/molgen/generate.py
+++ b/molgen/generate.py
@@ -45,7 +45,7 @@ def generate_nearby_smiles(
     model = BetaTCVAE(
         vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
     ).to(device)
-    model.load_state_dict(torch.load(model_path))
+    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     model.eval()
 
     tokenized_smiles = tokenizer.tokenize(smiles, max_len).unsqueeze(0).to(device)

--- a/molgen/interpolate.py
+++ b/molgen/interpolate.py
@@ -38,7 +38,7 @@ def interpolate_smiles(
     model = BetaTCVAE(
         vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
     ).to(device)
-    model.load_state_dict(torch.load(model_path))
+    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     model.eval()
 
     tokenized_smiles_1 = tokenizer.tokenize(smiles_1, max_len).unsqueeze(0).to(device)


### PR DESCRIPTION
Makes checkpoint loading portable and safe.

**Problem**: `torch.load(model_path)` was called with no `map_location`. A checkpoint saved on a GPU then fails with a CUDA-deserialization error on a CPU-only machine (and the reverse). It also deserialized with full pickle semantics.

**Fix**: in both `generate.py` and `interpolate.py`, load with `map_location=device` (so the checkpoint lands on whatever device the caller selected) and `weights_only=True` (load plain tensors without executing arbitrary pickled objects — also the safe default going forward).

**Validation**: the existing `tests/test_generate.py` round-trips a saved checkpoint through both entry points, so it exercises the new load path; `ruff` clean; `pytest` → 17 passed.
