### PR TITLE
Ignore padding positions in the reconstruction loss

### DIFF
--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -106,6 +106,7 @@ class BetaTCVAE(nn.Module):
         self.fc_out = nn.Linear(embedding_dim, vocab_size)
 
         self.device = device
+        self.pad_idx = pad_idx
 
     def reparameterize(self, mu, log_var):
         std = torch.exp(0.5 * log_var)
@@ -125,8 +126,10 @@ class BetaTCVAE(nn.Module):
         return out, mu, log_var
 
 
-def loss_function(recon_x, x, mu, log_var, beta, gamma):
-    BCE = F.cross_entropy(recon_x.view(-1, recon_x.size(-1)), x.view(-1), reduction="mean")
+def loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=-100):
+    BCE = F.cross_entropy(
+        recon_x.view(-1, recon_x.size(-1)), x.view(-1), ignore_index=pad_idx, reduction="mean"
+    )
     KLD = -0.5 * torch.mean(1 + log_var - mu.pow(2) - log_var.exp())
     TC = (log_var.exp() - 1 - log_var).mean()
 
@@ -142,7 +145,7 @@ def train(model, train_loader, optimizer, device, beta, gamma):
         optimizer.zero_grad()
 
         recon_x, mu, log_var = model(x)
-        loss = loss_function(recon_x, x, mu, log_var, beta, gamma)
+        loss = loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=model.pad_idx)
         loss.backward()
         total_loss += loss.item()
 
@@ -161,7 +164,7 @@ def test(model, test_loader, device, beta, gamma):
         for x in test_loader:
             x = x.to(device)
             recon_x, mu, log_var = model(x)
-            loss = loss_function(recon_x, x, mu, log_var, beta, gamma)
+            loss = loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=model.pad_idx)
             total_loss += loss.item()
 
             preds = torch.argmax(recon_x, dim=-1)

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -45,3 +45,24 @@ def test_backward_pass_populates_gradients():
     loss.backward()
     grads = [p.grad for p in model.parameters() if p.requires_grad]
     assert any(g is not None and torch.isfinite(g).all() for g in grads)
+
+
+def test_loss_ignores_pad_positions():
+    # Targets at positions 2, 3, 4 are padding (pad_idx=4).
+    x = torch.tensor([[0, 1, 4, 4, 4]])
+    mu = torch.zeros(1, 5, 4)
+    log_var = torch.zeros(1, 5, 4)
+    recon_a = torch.randn(1, 5, 6)
+    recon_b = recon_a.clone()
+    # Change the logits only at the padding positions.
+    recon_b[:, 2:, :] = torch.randn(1, 3, 6)
+
+    # With masking, padding positions are ignored, so the loss is unchanged.
+    loss_a = loss_function(recon_a, x, mu, log_var, beta=1.0, gamma=0.1, pad_idx=4)
+    loss_b = loss_function(recon_b, x, mu, log_var, beta=1.0, gamma=0.1, pad_idx=4)
+    assert torch.allclose(loss_a, loss_b)
+
+    # Without masking (default ignore_index), those positions do count.
+    loss_a_unmasked = loss_function(recon_a, x, mu, log_var, beta=1.0, gamma=0.1)
+    loss_b_unmasked = loss_function(recon_b, x, mu, log_var, beta=1.0, gamma=0.1)
+    assert not torch.allclose(loss_a_unmasked, loss_b_unmasked)


### PR DESCRIPTION
Fixes a training-signal bug in the VAE reconstruction loss.

**Problem**: `loss_function` computed `F.cross_entropy` over *all* token positions, including `<pad>`. Since padded sequences are mostly padding, the model spent most of its loss budget learning to predict the pad token.

**Fix**:
- `loss_function` gains a `pad_idx` argument forwarded to `cross_entropy(ignore_index=...)`; it defaults to `-100` so existing callers are unaffected.
- `BetaTCVAE` now stores `self.pad_idx`, and `train()` / `test()` pass `pad_idx=model.pad_idx` so padding is masked during real training.

**Test**: `test_loss_ignores_pad_positions` asserts that perturbing the logits at padding positions leaves the masked loss unchanged, but changes the unmasked loss.

**Validation**: `ruff check` clean; `pytest` → 18 passed.
