### PR TITLE
Exclude padding from the reconstruction accuracy metric

### DIFF
--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -136,6 +136,17 @@ def loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=-100):
     return BCE + beta * KLD + gamma * TC
 
 
+def masked_token_accuracy(preds, targets, pad_idx):
+    """Token-level accuracy over non-padding positions.
+
+    Returns ``(num_correct, num_tokens)`` so callers can aggregate across batches.
+    """
+    mask = targets != pad_idx
+    correct = int(((preds == targets) & mask).sum().item())
+    total = int(mask.sum().item())
+    return correct, total
+
+
 def train(model, train_loader, optimizer, device, beta, gamma):
     model.train()
     total_loss = 0
@@ -168,11 +179,12 @@ def test(model, test_loader, device, beta, gamma):
             total_loss += loss.item()
 
             preds = torch.argmax(recon_x, dim=-1)
-            correct += (preds == x).sum().item()
-            total += x.numel()
+            batch_correct, batch_total = masked_token_accuracy(preds, x, model.pad_idx)
+            correct += batch_correct
+            total += batch_total
 
     avg_loss = total_loss / len(test_loader)
-    avg_accuracy = correct / total
+    avg_accuracy = correct / total if total > 0 else 0.0
 
     return avg_loss, avg_accuracy
 

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from molgen.vae import BetaTCVAE, loss_function
+from molgen.vae import BetaTCVAE, loss_function, masked_token_accuracy
 
 
 def _tiny_model():
@@ -66,3 +66,17 @@ def test_loss_ignores_pad_positions():
     loss_a_unmasked = loss_function(recon_a, x, mu, log_var, beta=1.0, gamma=0.1)
     loss_b_unmasked = loss_function(recon_b, x, mu, log_var, beta=1.0, gamma=0.1)
     assert not torch.allclose(loss_a_unmasked, loss_b_unmasked)
+
+
+def test_masked_token_accuracy_excludes_padding():
+    preds = torch.tensor([[0, 1, 2, 3]])
+    targets = torch.tensor([[0, 1, 9, 9]])  # last two positions are padding (idx 9)
+    correct, total = masked_token_accuracy(preds, targets, pad_idx=9)
+    assert total == 2  # only the two non-padding positions are counted
+    assert correct == 2
+
+    # A wrong prediction at a non-pad position lowers the count; pad mismatches are ignored.
+    preds_wrong = torch.tensor([[0, 7, 2, 3]])
+    correct2, total2 = masked_token_accuracy(preds_wrong, targets, pad_idx=9)
+    assert total2 == 2
+    assert correct2 == 1


### PR DESCRIPTION
Fixes a misleading evaluation metric.

**Problem**: `test()` accumulated `correct += (preds == x).sum()` and `total += x.numel()` — counting padding positions. Because most of each padded sequence is `<pad>` (which the model predicts trivially), reported accuracy was heavily inflated and not a meaningful measure of reconstruction quality.

**Fix**: add `masked_token_accuracy(preds, targets, pad_idx)` that counts only non-padding positions and returns `(num_correct, num_tokens)` for correct cross-batch aggregation. `test()` uses it and guards against division by zero.

**Test**: `test_masked_token_accuracy_excludes_padding` checks that padded positions are ignored and that a wrong non-pad prediction lowers the count.

**Validation**: `ruff check` clean; `pytest` → 19 passed.
