### PR TITLE
Use batch_first attention and mask padding in the Transformer

### DIFF
--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -95,13 +95,15 @@ class BetaTCVAE(nn.Module):
 
         self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=pad_idx)
         self.encoder = nn.TransformerEncoder(
-            nn.TransformerEncoderLayer(embedding_dim, nhead, hidden_dim), num_layers=num_layers
+            nn.TransformerEncoderLayer(embedding_dim, nhead, hidden_dim, batch_first=True),
+            num_layers=num_layers,
         )
         self.mu = nn.Linear(embedding_dim, latent_dim)
         self.log_var = nn.Linear(embedding_dim, latent_dim)
 
         self.decoder = nn.TransformerDecoder(
-            nn.TransformerDecoderLayer(embedding_dim, nhead, hidden_dim), num_layers=num_layers
+            nn.TransformerDecoderLayer(embedding_dim, nhead, hidden_dim, batch_first=True),
+            num_layers=num_layers,
         )
         self.fc_out = nn.Linear(embedding_dim, vocab_size)
 
@@ -114,13 +116,20 @@ class BetaTCVAE(nn.Module):
         return mu + eps * std
 
     def forward(self, x):
+        # Mask padding positions so attention never attends to <pad> tokens.
+        pad_mask = x == self.pad_idx  # (batch, seq), True where padded
         embedded = self.embedding(x)
-        encoded = self.encoder(embedded)
+        encoded = self.encoder(embedded, src_key_padding_mask=pad_mask)
         mu = self.mu(encoded)
         log_var = self.log_var(encoded)
         z = self.reparameterize(mu, log_var)
 
-        decoded = self.decoder(z, encoded)
+        decoded = self.decoder(
+            z,
+            encoded,
+            tgt_key_padding_mask=pad_mask,
+            memory_key_padding_mask=pad_mask,
+        )
         out = self.fc_out(decoded)
 
         return out, mu, log_var

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -80,3 +80,17 @@ def test_masked_token_accuracy_excludes_padding():
     correct2, total2 = masked_token_accuracy(preds_wrong, targets, pad_idx=9)
     assert total2 == 2
     assert correct2 == 1
+
+
+def test_encoder_processes_sequences_independently():
+    # With batch_first attention each sequence is encoded independently of the
+    # other rows in the batch. Under the old batch_first=False bug, attention
+    # ran across the batch dimension and this invariant would fail.
+    model = _tiny_model()
+    model.eval()
+    a = torch.tensor([[0, 1, 2, 3, 0, 1]])
+    b = torch.tensor([[1, 1, 0, 0, 2, 3]])
+    with torch.no_grad():
+        enc_both = model.encoder(model.embedding(torch.cat([a, b], dim=0)))
+        enc_a = model.encoder(model.embedding(a))
+    assert torch.allclose(enc_both[0], enc_a[0], atol=1e-5)


### PR DESCRIPTION
Fixes two related correctness bugs in the Transformer VAE.

**Bugs**
1. `nn.TransformerEncoderLayer` / `nn.TransformerDecoderLayer` were created with the default `batch_first=False`, but the model feeds them `(batch, seq, embed)` tensors. PyTorch therefore treated the **batch** axis as the sequence axis — so self-attention mixed information *across different molecules in the batch*, and positions within a molecule were treated as independent batch elements.
2. Padding was never masked, so attention attended to `<pad>` tokens.

**Fix**
- `batch_first=True` on both the encoder and decoder layers.
- Build `pad_mask = (x == pad_idx)` and pass it as `src_key_padding_mask`, `tgt_key_padding_mask`, and `memory_key_padding_mask`.

**Test**: `test_encoder_processes_sequences_independently` encodes two sequences together and separately and asserts row 0 matches — this fails under the old cross-batch-attention behaviour. (Also removes the `enable_nested_tensor` warning.)

**Validation**: `ruff check` clean; `pytest` → 20 passed.
