### PR TITLE
Add sinusoidal positional encoding to the Transformer VAE

### DIFF
--- a/molgen/utils.py
+++ b/molgen/utils.py
@@ -43,9 +43,7 @@ def get_logger(name: str = "molgen", level: int = logging.INFO) -> logging.Logge
     logger = logging.getLogger(name)
     if not logger.handlers:
         handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-        )
+        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
         logger.addHandler(handler)
         logger.setLevel(level)
         logger.propagate = False

--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -1,3 +1,5 @@
+import math
+
 import pandas as pd
 import torch
 import torch.nn as nn
@@ -87,6 +89,24 @@ class SimpleTokenizer:
         return torch.tensor(tokenized_smiles, dtype=torch.long)
 
 
+class PositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding for batch-first (batch, seq, dim) inputs."""
+
+    def __init__(self, embedding_dim, max_len=2048):
+        super().__init__()
+        pe = torch.zeros(max_len, embedding_dim)
+        position = torch.arange(max_len).unsqueeze(1).float()
+        div_term = torch.exp(
+            torch.arange(0, embedding_dim, 2).float() * (-math.log(10000.0) / embedding_dim)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term[: embedding_dim // 2])
+        self.register_buffer("pe", pe.unsqueeze(0))  # (1, max_len, embedding_dim)
+
+    def forward(self, x):
+        return x + self.pe[:, : x.size(1)]
+
+
 class BetaTCVAE(nn.Module):
     def __init__(
         self, vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
@@ -94,6 +114,7 @@ class BetaTCVAE(nn.Module):
         super(BetaTCVAE, self).__init__()
 
         self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=pad_idx)
+        self.pos_encoder = PositionalEncoding(embedding_dim)
         self.encoder = nn.TransformerEncoder(
             nn.TransformerEncoderLayer(embedding_dim, nhead, hidden_dim, batch_first=True),
             num_layers=num_layers,
@@ -118,7 +139,7 @@ class BetaTCVAE(nn.Module):
     def forward(self, x):
         # Mask padding positions so attention never attends to <pad> tokens.
         pad_mask = x == self.pad_idx  # (batch, seq), True where padded
-        embedded = self.embedding(x)
+        embedded = self.pos_encoder(self.embedding(x))
         encoded = self.encoder(embedded, src_key_padding_mask=pad_mask)
         mu = self.mu(encoded)
         log_var = self.log_var(encoded)

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from molgen.vae import BetaTCVAE, loss_function, masked_token_accuracy
+from molgen.vae import BetaTCVAE, PositionalEncoding, loss_function, masked_token_accuracy
 
 
 def _tiny_model():
@@ -94,3 +94,11 @@ def test_encoder_processes_sequences_independently():
         enc_both = model.encoder(model.embedding(torch.cat([a, b], dim=0)))
         enc_a = model.encoder(model.embedding(a))
     assert torch.allclose(enc_both[0], enc_a[0], atol=1e-5)
+
+
+def test_positional_encoding_is_position_dependent():
+    pe = PositionalEncoding(embedding_dim=16)
+    out = pe(torch.zeros(1, 10, 16))
+    assert out.shape == (1, 10, 16)
+    # With a zero input the output is the positional code, which differs per position.
+    assert not torch.allclose(out[0, 0], out[0, 1])


### PR DESCRIPTION
Adds positional information to the Transformer VAE.

**Problem**: the model embedded tokens and fed them straight to the Transformer encoder with no positional encoding. Self-attention is permutation-invariant, so the model could not distinguish token order — e.g. `CCO` and `OCC` looked identical to the encoder.

**Fix**: add a standard sinusoidal `PositionalEncoding` module (batch-first, robust to odd embedding dims) and apply it to the embeddings before the encoder.

**Test**: `test_positional_encoding_is_position_dependent` confirms the encoding differs across positions; existing forward/shape tests still pass.

**Validation**: `ruff check` clean; `pytest` → 21 passed.
