### PR TITLE
Derive vocab size and pad index from the tokenizer

### DIFF
--- a/molgen/generate.py
+++ b/molgen/generate.py
@@ -34,13 +34,13 @@ def generate_nearby_smiles(
         list of str: List of generated SMILES strings.
     """
     # Load the model
-    vocab_size = 6
+    vocab_size = tokenizer.vocab_size
     embedding_dim = 16
     hidden_dim = 64
     latent_dim = 16
     nhead = 4
     num_layers = 2
-    pad_idx = 4
+    pad_idx = tokenizer.pad_idx
 
     model = BetaTCVAE(
         vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device

--- a/molgen/interpolate.py
+++ b/molgen/interpolate.py
@@ -27,13 +27,13 @@ def interpolate_smiles(
         list of str: List of interpolated SMILES strings.
     """
     # Load the model
-    vocab_size = 6
+    vocab_size = tokenizer.vocab_size
     embedding_dim = 16
     hidden_dim = 64
     latent_dim = 16
     nhead = 4
     num_layers = 2
-    pad_idx = 4
+    pad_idx = tokenizer.pad_idx
 
     model = BetaTCVAE(
         vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device

--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -72,6 +72,7 @@ class SimpleTokenizer:
         self.char_to_idx = {"C": 0, "O": 1, "(": 2, ")": 3, "<pad>": 4}
         self.idx_to_char = {v: k for k, v in self.char_to_idx.items()}
         self.pad_idx = self.char_to_idx["<pad>"]
+        self.vocab_size = len(self.char_to_idx)
 
     def tokenize(self, smiles, max_len):
         """
@@ -230,13 +231,13 @@ def main():
     )
 
     # Hyperparameters
-    vocab_size = 6  # Set according to the actual vocabulary size
+    vocab_size = simple_tokenizer.vocab_size
     embedding_dim = 16
     hidden_dim = 64
     latent_dim = 16
     nhead = 4
     num_layers = 2
-    pad_idx = 4  # Set according to the actual padding index
+    pad_idx = simple_tokenizer.pad_idx
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # Create the model

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -9,15 +9,16 @@ from molgen.vae import BetaTCVAE, SimpleTokenizer
 
 
 def _save_tiny_model(path):
-    # Architecture must match the hyperparameters hardcoded in generate/interpolate.
+    # Architecture must match the config generate/interpolate derive from the tokenizer.
+    tok = SimpleTokenizer()
     model = BetaTCVAE(
-        vocab_size=6,
+        vocab_size=tok.vocab_size,
         embedding_dim=16,
         hidden_dim=64,
         latent_dim=16,
         nhead=4,
         num_layers=2,
-        pad_idx=4,
+        pad_idx=tok.pad_idx,
         device=torch.device("cpu"),
     )
     torch.save(model.state_dict(), path)

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -27,3 +27,8 @@ def test_tokenize_decode_roundtrip():
     out = tok.tokenize(smiles, max_len=len(smiles))
     decoded = "".join(tok.idx_to_char[int(i)] for i in out)
     assert decoded == smiles
+
+
+def test_vocab_size_matches_token_count():
+    tok = SimpleTokenizer()
+    assert tok.vocab_size == len(tok.char_to_idx) == 5


### PR DESCRIPTION
Removes a vocabulary-size inconsistency.

**Problem**: `SimpleTokenizer` defines 5 tokens (`C`, `O`, `(`, `)`, `<pad>` → indices 0–4), but `vocab_size` was hardcoded as `6` in `vae.py`, `generate.py`, and `interpolate.py`. The model therefore carried an extra never-used class (index 5), and the generation code had to clamp predictions with `min(int(idx), 4)`.

**Fix**: expose `vocab_size` on `SimpleTokenizer` (`len(char_to_idx)`), and derive both `vocab_size` and `pad_idx` from the tokenizer instead of magic numbers — keeping the model and tokenizer in sync by construction.

**Tests**: `test_vocab_size_matches_token_count` checks the new attribute; `tests/test_generate.py` now builds its checkpoint from the tokenizer-derived config so it keeps matching the entry points.

**Validation**: `ruff check` clean; `pytest` → 22 passed.
