### PR TITLE
Add RDKit chemistry utilities (validate, canonicalize, randomize)

### DIFF
--- a/molgen/chem.py
+++ b/molgen/chem.py
@@ -1,0 +1,40 @@
+"""Cheminformatics helpers built on RDKit.
+
+Invalid SMILES are reported by returning ``None`` (or ``False``) rather than
+raising, so callers can filter generated strings cheaply. RDKit's own parser
+logging is silenced at import time since those errors are expected here.
+"""
+
+from __future__ import annotations
+
+from rdkit import Chem, RDLogger
+
+RDLogger.DisableLog("rdApp.*")
+
+__all__ = ["is_valid_smiles", "canonicalize_smiles", "randomize_smiles"]
+
+
+def is_valid_smiles(smiles: str) -> bool:
+    """Return True if RDKit can parse ``smiles`` into a molecule."""
+    return Chem.MolFromSmiles(smiles) is not None
+
+
+def canonicalize_smiles(smiles: str) -> str | None:
+    """Return the RDKit canonical SMILES for ``smiles``, or None if invalid."""
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    return Chem.MolToSmiles(mol)
+
+
+def randomize_smiles(smiles: str) -> str | None:
+    """Return a random (non-canonical) SMILES for the same molecule.
+
+    This is useful as data augmentation ("SMILES enumeration"): the same
+    molecule is written with a different atom ordering each call. Returns
+    None if the input cannot be parsed.
+    """
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    return Chem.MolToSmiles(mol, doRandom=True, canonical=False)

--- a/tests/test_chem.py
+++ b/tests/test_chem.py
@@ -1,0 +1,32 @@
+"""Tests for the RDKit chemistry helpers."""
+
+from molgen.chem import canonicalize_smiles, is_valid_smiles, randomize_smiles
+
+
+def test_is_valid_smiles():
+    assert is_valid_smiles("CCO")
+    assert is_valid_smiles("c1ccccc1")
+    assert not is_valid_smiles("C(C")  # unbalanced parenthesis
+    assert not is_valid_smiles("not a molecule")
+
+
+def test_canonicalize_is_idempotent_and_order_invariant():
+    canon = canonicalize_smiles("OCC")
+    assert canon is not None
+    assert canonicalize_smiles(canon) == canon
+    # Different writings of ethanol map to the same canonical SMILES.
+    assert canonicalize_smiles("OCC") == canonicalize_smiles("CCO")
+
+
+def test_canonicalize_invalid_returns_none():
+    assert canonicalize_smiles("xyz%%") is None
+
+
+def test_randomize_smiles_preserves_molecule():
+    rnd = randomize_smiles("c1ccccc1")
+    assert rnd is not None
+    assert canonicalize_smiles(rnd) == canonicalize_smiles("c1ccccc1")
+
+
+def test_randomize_invalid_returns_none():
+    assert randomize_smiles("???") is None


### PR DESCRIPTION
Adds a small cheminformatics helper module that later phases (data cleaning, metrics, SMILES-enumeration augmentation) build on.

**`molgen/chem.py`**
- `is_valid_smiles(s)` — whether RDKit can parse the string.
- `canonicalize_smiles(s)` — RDKit canonical SMILES, or `None` if invalid.
- `randomize_smiles(s)` — a random (non-canonical) SMILES for the same molecule, useful as data augmentation.

Invalid input returns `None`/`False` instead of raising, and RDKit's noisy parse logging is disabled (the errors are expected when filtering generated strings).

**Tests** (`tests/test_chem.py`): validity, canonicalization idempotence + order-invariance, invalid → `None`, and that randomization preserves the molecule.

**Validation**: `ruff check` clean; `pytest` → 27 passed.
