### PR TITLE
Add an atom-aware regex SMILES tokenizer

### DIFF
--- a/molgen/tokenizers.py
+++ b/molgen/tokenizers.py
@@ -1,0 +1,112 @@
+"""SMILES tokenization.
+
+Provides an atom-aware, regex-based SMILES tokenizer with explicit special
+tokens and a corpus-built vocabulary. This replaces the toy character map
+that only handled ``C``, ``O``, ``(`` and ``)``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable, Sequence
+
+import torch
+
+# Atom-level SMILES regex from Schwaller et al., "Molecular Transformer" (2019).
+# Matches bracket atoms, two-letter atoms (Br, Cl), the organic subset,
+# bonds, ring-closure digits, and stereochemistry markers.
+SMILES_REGEX = (
+    r"(\[[^\]]+\]|Br?|Cl?|N|O|S|P|F|I|b|c|n|o|s|p|"
+    r"\(|\)|\.|=|#|-|\+|\\|/|:|~|@|\?|>|\*|\$|%[0-9]{2}|[0-9])"
+)
+_TOKEN_RE = re.compile(SMILES_REGEX)
+
+PAD_TOKEN = "<pad>"
+BOS_TOKEN = "<bos>"
+EOS_TOKEN = "<eos>"
+UNK_TOKEN = "<unk>"
+SPECIAL_TOKENS = [PAD_TOKEN, BOS_TOKEN, EOS_TOKEN, UNK_TOKEN]
+
+
+def smiles_tokens(smiles: str) -> list[str]:
+    """Split a SMILES string into atom/bond tokens using the atom-level regex."""
+    return _TOKEN_RE.findall(smiles)
+
+
+class SmilesTokenizer:
+    """Maps SMILES strings to/from integer id sequences.
+
+    The vocabulary is an ordered list of tokens whose first entries are the
+    special tokens (pad/bos/eos/unk). Build one from a corpus with
+    :meth:`from_smiles`.
+    """
+
+    def __init__(self, vocab: Sequence[str]):
+        self.itos = list(vocab)
+        self.stoi = {tok: i for i, tok in enumerate(self.itos)}
+        for tok in SPECIAL_TOKENS:
+            if tok not in self.stoi:
+                raise ValueError(f"vocab is missing required special token {tok!r}")
+        self.pad_id = self.stoi[PAD_TOKEN]
+        self.bos_id = self.stoi[BOS_TOKEN]
+        self.eos_id = self.stoi[EOS_TOKEN]
+        self.unk_id = self.stoi[UNK_TOKEN]
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.itos)
+
+    @classmethod
+    def from_smiles(cls, smiles_iter: Iterable[str], min_freq: int = 1) -> SmilesTokenizer:
+        """Build a tokenizer from a corpus, keeping tokens with count >= min_freq."""
+        counter: Counter[str] = Counter()
+        for smi in smiles_iter:
+            counter.update(smiles_tokens(smi))
+        # Deterministic order: by descending frequency, then lexicographically.
+        tokens = [
+            tok
+            for tok, count in sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+            if count >= min_freq
+        ]
+        return cls(SPECIAL_TOKENS + tokens)
+
+    def tokenize(self, smiles: str) -> list[str]:
+        return smiles_tokens(smiles)
+
+    def encode(
+        self, smiles: str, add_bos_eos: bool = True, max_len: int | None = None
+    ) -> list[int]:
+        """Encode a SMILES string into token ids, optionally padded/truncated."""
+        ids = [self.stoi.get(tok, self.unk_id) for tok in smiles_tokens(smiles)]
+        if add_bos_eos:
+            ids = [self.bos_id, *ids, self.eos_id]
+        if max_len is not None:
+            ids = ids[:max_len] + [self.pad_id] * (max_len - len(ids))
+        return ids
+
+    def decode(self, ids: Sequence[int], strip_special: bool = True) -> str:
+        """Decode token ids back into a SMILES string.
+
+        When ``strip_special`` is set, decoding stops at the first EOS and
+        pad/bos/eos tokens are dropped.
+        """
+        specials = {self.pad_id, self.bos_id, self.eos_id}
+        out: list[str] = []
+        for raw in ids:
+            i = int(raw)
+            if strip_special:
+                if i == self.eos_id:
+                    break
+                if i in specials:
+                    continue
+            out.append(self.itos[i] if 0 <= i < len(self.itos) else UNK_TOKEN)
+        return "".join(out)
+
+    def encode_batch(self, smiles_list: Sequence[str], max_len: int | None = None) -> torch.Tensor:
+        """Encode a list of SMILES into a padded ``(batch, seq)`` LongTensor."""
+        encoded = [self.encode(s, add_bos_eos=True, max_len=max_len) for s in smiles_list]
+        if max_len is None:
+            width = max(len(e) for e in encoded)
+            encoded = [e + [self.pad_id] * (width - len(e)) for e in encoded]
+        return torch.tensor(encoded, dtype=torch.long)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,0 +1,68 @@
+"""Tests for the regex SMILES tokenizer."""
+
+import torch
+
+from molgen.tokenizers import SPECIAL_TOKENS, SmilesTokenizer, smiles_tokens
+
+
+def test_smiles_tokens_are_atom_level():
+    assert smiles_tokens("Cc1ccc(Cl)cc1") == [
+        "C",
+        "c",
+        "1",
+        "c",
+        "c",
+        "c",
+        "(",
+        "Cl",
+        ")",
+        "c",
+        "c",
+        "1",
+    ]
+    # Bracket atoms are a single token.
+    assert smiles_tokens("[nH]") == ["[nH]"]
+    assert smiles_tokens("[C@@H]") == ["[C@@H]"]
+
+
+def test_from_smiles_includes_specials_and_atoms():
+    tok = SmilesTokenizer.from_smiles(["CCO", "CCN"])
+    for special in SPECIAL_TOKENS:
+        assert special in tok.stoi
+    assert {"C", "O", "N"} <= set(tok.stoi)
+    assert tok.vocab_size == len(tok.itos)
+
+
+def test_encode_decode_roundtrip():
+    tok = SmilesTokenizer.from_smiles(["CCO", "c1ccccc1", "CC(=O)O"])
+    smiles = "CC(=O)O"
+    ids = tok.encode(smiles)
+    assert ids[0] == tok.bos_id
+    assert ids[-1] == tok.eos_id
+    assert tok.decode(ids) == smiles
+
+
+def test_encode_pads_and_truncates_to_max_len():
+    tok = SmilesTokenizer.from_smiles(["CCO"])
+    ids = tok.encode("CCO", max_len=10)
+    assert len(ids) == 10
+    assert ids[-1] == tok.pad_id
+
+    short = tok.encode("CCO", max_len=3)
+    assert len(short) == 3
+
+
+def test_unknown_tokens_map_to_unk():
+    tok = SmilesTokenizer.from_smiles(["CCO"])  # vocab: C, O (+ specials)
+    ids = tok.encode("CCN", add_bos_eos=False)  # N is out of vocabulary
+    assert tok.unk_id in ids
+
+
+def test_encode_batch_returns_padded_long_tensor():
+    tok = SmilesTokenizer.from_smiles(["CCO", "CCN", "c1ccccc1"])
+    batch = tok.encode_batch(["CCO", "c1ccccc1"])
+    assert isinstance(batch, torch.Tensor)
+    assert batch.dtype == torch.long
+    assert batch.shape[0] == 2
+    # All rows share a common (padded) width.
+    assert batch.shape[1] == max(len(tok.encode("CCO")), len(tok.encode("c1ccccc1")))


### PR DESCRIPTION
Adds a real SMILES tokenizer so the project can model arbitrary molecules, not just the toy `C/O/()` alphabet.

**`molgen/tokenizers.py`**
- `smiles_tokens()` — atom-level tokenization via the Schwaller et al. ("Molecular Transformer") regex: two-letter atoms (`Cl`, `Br`), bracket atoms (`[nH]`, `[C@@H]`), ring-closure digits, bonds, and stereo markers each become a single token.
- `SmilesTokenizer` — ordered vocab with explicit `<pad>/<bos>/<eos>/<unk>`, built from a corpus via `from_smiles(..., min_freq=...)` (deterministic ordering), plus `encode` (optional BOS/EOS, padding/truncation), `decode` (stops at EOS, strips specials), and `encode_batch` → padded `(batch, seq)` LongTensor.

**Tests** (`tests/test_tokenizers.py`): atom-level splitting incl. bracket/two-letter atoms, vocab construction, encode/decode round-trip, padding/truncation, unknown→`<unk>`, and batch encoding shape/dtype.

**Validation**: `ruff check` clean; `pytest` → 33 passed.
