### PR TITLE
Add a SELFIES tokenizer with guaranteed-valid decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
         # Use the CPU wheel index to avoid pulling large CUDA dependencies on CI.
         run: pip install torch --index-url https://download.pytorch.org/whl/cpu
 
-      - name: Install package (with dev extras)
-        run: pip install -e ".[dev]"
+      - name: Install package (with dev + selfies extras)
+        run: pip install -e ".[dev,selfies]"
 
       - name: Ruff lint
         run: ruff check .

--- a/molgen/selfies_tokenizer.py
+++ b/molgen/selfies_tokenizer.py
@@ -1,0 +1,101 @@
+"""SELFIES-based tokenization.
+
+SELFIES (Krenn et al., 2020) is a molecular string representation in which
+*every* symbol sequence decodes to a valid molecule. This is attractive for
+generation: a model can emit arbitrary SELFIES symbols and the decoder still
+yields a syntactically valid SMILES.
+
+Requires the optional ``selfies`` dependency (``pip install molgen[selfies]``).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Sequence
+
+import selfies as sf
+import torch
+
+from molgen.tokenizers import BOS_TOKEN, EOS_TOKEN, PAD_TOKEN, SPECIAL_TOKENS, UNK_TOKEN
+
+
+class SelfiesTokenizer:
+    """Maps SMILES to/from integer ids via the SELFIES representation."""
+
+    def __init__(self, vocab: Sequence[str]):
+        self.itos = list(vocab)
+        self.stoi = {tok: i for i, tok in enumerate(self.itos)}
+        for tok in SPECIAL_TOKENS:
+            if tok not in self.stoi:
+                raise ValueError(f"vocab is missing required special token {tok!r}")
+        self.pad_id = self.stoi[PAD_TOKEN]
+        self.bos_id = self.stoi[BOS_TOKEN]
+        self.eos_id = self.stoi[EOS_TOKEN]
+        self.unk_id = self.stoi[UNK_TOKEN]
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.itos)
+
+    @staticmethod
+    def smiles_to_selfies(smiles: str) -> str | None:
+        """Return the SELFIES encoding of ``smiles``, or None if it cannot be encoded."""
+        try:
+            return sf.encoder(smiles)
+        except Exception:
+            return None
+
+    @classmethod
+    def from_smiles(cls, smiles_iter: Iterable[str], min_freq: int = 1) -> SelfiesTokenizer:
+        """Build a tokenizer by collecting SELFIES symbols from a SMILES corpus."""
+        counter: Counter[str] = Counter()
+        for smi in smiles_iter:
+            encoded = cls.smiles_to_selfies(smi)
+            if encoded is None:
+                continue
+            counter.update(sf.split_selfies(encoded))
+        symbols = [
+            sym
+            for sym, count in sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+            if count >= min_freq
+        ]
+        return cls(SPECIAL_TOKENS + symbols)
+
+    def tokenize(self, smiles: str) -> list[str]:
+        encoded = self.smiles_to_selfies(smiles)
+        return list(sf.split_selfies(encoded)) if encoded is not None else []
+
+    def encode(
+        self, smiles: str, add_bos_eos: bool = True, max_len: int | None = None
+    ) -> list[int]:
+        ids = [self.stoi.get(sym, self.unk_id) for sym in self.tokenize(smiles)]
+        if add_bos_eos:
+            ids = [self.bos_id, *ids, self.eos_id]
+        if max_len is not None:
+            ids = ids[:max_len] + [self.pad_id] * (max_len - len(ids))
+        return ids
+
+    def decode(self, ids: Sequence[int]) -> str:
+        """Decode ids back to a SMILES string (always syntactically valid).
+
+        Stops at the first EOS and skips pad/bos/unk; the remaining SELFIES
+        symbols are joined and decoded via the SELFIES decoder.
+        """
+        skip = {self.pad_id, self.bos_id, self.unk_id}
+        symbols: list[str] = []
+        for raw in ids:
+            i = int(raw)
+            if i == self.eos_id:
+                break
+            if i in skip:
+                continue
+            if 0 <= i < len(self.itos):
+                symbols.append(self.itos[i])
+        return sf.decoder("".join(symbols))
+
+    def encode_batch(self, smiles_list: Sequence[str], max_len: int | None = None) -> torch.Tensor:
+        encoded = [self.encode(s, add_bos_eos=True, max_len=max_len) for s in smiles_list]
+        if max_len is None:
+            width = max(len(e) for e in encoded)
+            encoded = [e + [self.pad_id] * (width - len(e)) for e in encoded]
+        return torch.tensor(encoded, dtype=torch.long)

--- a/tests/test_selfies_tokenizer.py
+++ b/tests/test_selfies_tokenizer.py
@@ -1,0 +1,35 @@
+"""Tests for the SELFIES tokenizer (skipped if the optional dep is absent)."""
+
+import random
+
+import pytest
+
+pytest.importorskip("selfies")
+
+from molgen.chem import canonicalize_smiles, is_valid_smiles  # noqa: E402
+from molgen.selfies_tokenizer import SelfiesTokenizer  # noqa: E402
+
+
+def test_from_smiles_includes_special_tokens():
+    tok = SelfiesTokenizer.from_smiles(["CCO", "CCN", "c1ccccc1"])
+    assert tok.pad_id == 0
+    assert tok.vocab_size > 4  # specials plus at least a few SELFIES symbols
+
+
+def test_encode_decode_recovers_molecule():
+    tok = SelfiesTokenizer.from_smiles(["CCO", "c1ccccc1", "CC(=O)O"])
+    ids = tok.encode("CC(=O)O")
+    assert ids[0] == tok.bos_id
+    assert ids[-1] == tok.eos_id
+    decoded = tok.decode(ids)
+    assert canonicalize_smiles(decoded) == canonicalize_smiles("CC(=O)O")
+
+
+def test_random_ids_always_decode_to_valid_smiles():
+    # The defining property of SELFIES: any symbol sequence is a valid molecule.
+    tok = SelfiesTokenizer.from_smiles(["CCO", "CCN", "c1ccccc1", "CC(=O)O", "C1CCCCC1"])
+    random.seed(0)
+    for _ in range(50):
+        ids = [random.randrange(tok.vocab_size) for _ in range(12)]
+        smiles = tok.decode(ids)
+        assert smiles == "" or is_valid_smiles(smiles)


### PR DESCRIPTION
Adds an alternative molecular representation whose key property is **100% validity**: with SELFIES (Krenn et al., 2020) every token sequence decodes to a valid molecule, so a generator can never emit a syntactically invalid string. (Per Skinnider 2024, SMILES still tends to win on distribution-learning, so both representations are offered rather than replacing SMILES.)

**`molgen/selfies_tokenizer.py`** — `SelfiesTokenizer` with the same interface as `SmilesTokenizer` (`from_smiles`, `encode`, `decode`, `encode_batch`, special tokens). SMILES → SELFIES on encode, SELFIES → SMILES on decode. Kept in its own module so `import molgen.tokenizers` doesn't require the optional `selfies` package.

**Packaging/CI**: `selfies` stays an optional extra; CI now installs `.[dev,selfies]` so these tests run. The test module `pytest.importorskip("selfies")`s so the suite still passes without it.

**Tests**: vocab construction, encode/decode round-trip (canonical match), and — demonstrating the core property — 50 random id sequences all decode to valid SMILES.

**Validation**: `ruff check` clean; `pytest` → 36 passed (3 SELFIES tests).
