### PR TITLE
Add SMILES dataset and data loaders with dynamic padding

### DIFF
--- a/molgen/data.py
+++ b/molgen/data.py
@@ -1,0 +1,81 @@
+"""Datasets and data loading for SMILES sequence models."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import partial
+
+import pandas as pd
+import torch
+from sklearn.model_selection import train_test_split
+from torch.utils.data import DataLoader, Dataset
+
+
+class SmilesDataset(Dataset):
+    """A dataset of SMILES strings encoded to token-id tensors.
+
+    Each item is a 1-D LongTensor of token ids (with BOS/EOS). Padding is done
+    dynamically per batch by :func:`make_collate_fn`, not stored per item, so
+    short molecules don't waste memory.
+    """
+
+    def __init__(self, smiles_list: Sequence[str], tokenizer, max_len: int | None = None):
+        self.smiles_list = list(smiles_list)
+        self.tokenizer = tokenizer
+        self.max_len = max_len
+
+    def __len__(self) -> int:
+        return len(self.smiles_list)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        ids = self.tokenizer.encode(self.smiles_list[idx], add_bos_eos=True, max_len=self.max_len)
+        return torch.tensor(ids, dtype=torch.long)
+
+
+def _pad_collate(batch: list[torch.Tensor], pad_id: int) -> torch.Tensor:
+    """Pad a list of 1-D id tensors to the longest in the batch -> (batch, seq)."""
+    width = max(t.size(0) for t in batch)
+    out = torch.full((len(batch), width), pad_id, dtype=torch.long)
+    for i, t in enumerate(batch):
+        out[i, : t.size(0)] = t
+    return out
+
+
+def make_collate_fn(pad_id: int):
+    """Return a picklable collate function that pads batches to a common length."""
+    return partial(_pad_collate, pad_id=pad_id)
+
+
+def read_smiles_csv(path: str, column: str = "SMILES") -> list[str]:
+    """Read a column of SMILES strings from a CSV file."""
+    return pd.read_csv(path)[column].astype(str).tolist()
+
+
+def build_dataloaders(
+    smiles_list: Sequence[str],
+    tokenizer,
+    batch_size: int = 64,
+    test_split: float = 0.1,
+    max_len: int | None = None,
+    shuffle: bool = True,
+    num_workers: int = 0,
+    seed: int = 42,
+) -> tuple[DataLoader, DataLoader]:
+    """Split SMILES into train/test sets and build padded DataLoaders."""
+    train_smiles, test_smiles = train_test_split(
+        list(smiles_list), test_size=test_split, random_state=seed
+    )
+    collate = make_collate_fn(tokenizer.pad_id)
+    train_ds = SmilesDataset(train_smiles, tokenizer, max_len)
+    test_ds = SmilesDataset(test_smiles, tokenizer, max_len)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        collate_fn=collate,
+    )
+    test_loader = DataLoader(
+        test_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers, collate_fn=collate
+    )
+    return train_loader, test_loader

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,43 @@
+"""Tests for the SMILES dataset and data loaders."""
+
+import torch
+
+from molgen.data import SmilesDataset, build_dataloaders, make_collate_fn
+from molgen.tokenizers import SmilesTokenizer
+
+SMILES = ["CCO", "CCN", "c1ccccc1", "CC(=O)O", "C1CCCCC1", "CCCl", "CCBr", "CCS"]
+
+
+def _tokenizer():
+    return SmilesTokenizer.from_smiles(SMILES)
+
+
+def test_dataset_item_is_long_tensor_with_bos_eos():
+    tok = _tokenizer()
+    ds = SmilesDataset(["CCO"], tok)
+    item = ds[0]
+    assert item.dtype == torch.long
+    assert item[0].item() == tok.bos_id
+    assert item[-1].item() == tok.eos_id
+
+
+def test_collate_pads_to_longest_in_batch():
+    tok = _tokenizer()
+    collate = make_collate_fn(tok.pad_id)
+    a = torch.tensor([1, 2, 3])
+    b = torch.tensor([4, 5])
+    out = collate([a, b])
+    assert out.shape == (2, 3)
+    assert out[1, 2].item() == tok.pad_id  # shorter row is padded
+
+
+def test_build_dataloaders_yields_batches():
+    tok = _tokenizer()
+    train_loader, test_loader = build_dataloaders(SMILES, tok, batch_size=4, test_split=0.25)
+    batch = next(iter(train_loader))
+    assert batch.dim() == 2
+    assert batch.dtype == torch.long
+    # Train/test split sizes add up to the corpus size.
+    n_train = len(train_loader.dataset)
+    n_test = len(test_loader.dataset)
+    assert n_train + n_test == len(SMILES)


### PR DESCRIPTION
Connects the new atom-level tokenizer to a proper data pipeline.

**`molgen/data.py`**
- `SmilesDataset` — encodes each SMILES to a 1-D id tensor (with BOS/EOS) using a `SmilesTokenizer`.
- `make_collate_fn(pad_id)` — returns a **picklable** (`functools.partial`) collate that pads each batch to its own longest sequence, rather than padding everything to a global `max_len` (less wasted compute on short molecules; works with `num_workers > 0`).
- `read_smiles_csv()` and `build_dataloaders()` — read a corpus and build reproducible train/test `DataLoader`s with the pad-collate.

**Tests** (`tests/test_data.py`): dataset item dtype + BOS/EOS, collate padding to batch-max, and that `build_dataloaders` yields 2-D long batches with a train/test split that sums to the corpus size.

**Validation**: `ruff check` clean; `pytest` → 41 passed.
