### PR TITLE
Add SMILES enumeration augmentation to the dataset

### DIFF
--- a/molgen/data.py
+++ b/molgen/data.py
@@ -11,6 +11,8 @@ import torch
 from sklearn.model_selection import train_test_split
 from torch.utils.data import DataLoader, Dataset
 
+from molgen.chem import randomize_smiles
+
 
 class SmilesDataset(Dataset):
     """A dataset of SMILES strings encoded to token-id tensors.
@@ -20,16 +22,29 @@ class SmilesDataset(Dataset):
     short molecules don't waste memory.
     """
 
-    def __init__(self, smiles_list: Sequence[str], tokenizer, max_len: int | None = None):
+    def __init__(
+        self,
+        smiles_list: Sequence[str],
+        tokenizer,
+        max_len: int | None = None,
+        augment: bool = False,
+    ):
         self.smiles_list = list(smiles_list)
         self.tokenizer = tokenizer
         self.max_len = max_len
+        self.augment = augment
 
     def __len__(self) -> int:
         return len(self.smiles_list)
 
     def __getitem__(self, idx: int) -> torch.Tensor:
-        ids = self.tokenizer.encode(self.smiles_list[idx], add_bos_eos=True, max_len=self.max_len)
+        smiles = self.smiles_list[idx]
+        if self.augment:
+            # SMILES enumeration: a random valid ordering of the same molecule.
+            randomized = randomize_smiles(smiles)
+            if randomized is not None:
+                smiles = randomized
+        ids = self.tokenizer.encode(smiles, add_bos_eos=True, max_len=self.max_len)
         return torch.tensor(ids, dtype=torch.long)
 
 
@@ -61,13 +76,18 @@ def build_dataloaders(
     shuffle: bool = True,
     num_workers: int = 0,
     seed: int = 42,
+    augment: bool = False,
 ) -> tuple[DataLoader, DataLoader]:
-    """Split SMILES into train/test sets and build padded DataLoaders."""
+    """Split SMILES into train/test sets and build padded DataLoaders.
+
+    When ``augment`` is set, the training set uses SMILES enumeration (a random
+    valid ordering per access); the test set is never augmented.
+    """
     train_smiles, test_smiles = train_test_split(
         list(smiles_list), test_size=test_split, random_state=seed
     )
     collate = make_collate_fn(tokenizer.pad_id)
-    train_ds = SmilesDataset(train_smiles, tokenizer, max_len)
+    train_ds = SmilesDataset(train_smiles, tokenizer, max_len, augment=augment)
     test_ds = SmilesDataset(test_smiles, tokenizer, max_len)
     train_loader = DataLoader(
         train_ds,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -49,3 +49,16 @@ def test_load_sample_smiles_returns_valid_molecules():
     assert len(smiles) >= 100
     # Spot-check that the bundled molecules parse.
     assert all(is_valid_smiles(s) for s in smiles[:50])
+
+
+def test_augmentation_preserves_the_molecule():
+    from molgen.chem import canonicalize_smiles
+
+    smiles = "CCOc1ccccc1"
+    tok = SmilesTokenizer.from_smiles([smiles, *load_sample_smiles()])
+    ds = SmilesDataset([smiles], tok, augment=True)
+    target = canonicalize_smiles(smiles)
+    # Each augmented encoding is a different ordering of the *same* molecule.
+    for _ in range(10):
+        decoded = tok.decode(ds[0].tolist())
+        assert canonicalize_smiles(decoded) == target


### PR DESCRIPTION
Adds SMILES-enumeration data augmentation, a standard and effective regularizer for SMILES sequence models (Bjerrum, 2017): the same molecule is presented with different (valid) atom orderings each epoch.

**Changes**
- `SmilesDataset(..., augment=False)` — when set, `__getitem__` returns a random non-canonical SMILES of the molecule (via `randomize_smiles`), falling back to the original if randomization fails.
- `build_dataloaders(..., augment=False)` — applies augmentation to the **training** set only; the test set stays canonical/deterministic.

**Test**: `test_augmentation_preserves_the_molecule` decodes ten augmented encodings and asserts each canonicalizes back to the original molecule.

**Validation**: `ruff check` clean; `pytest` → 43 passed.
