### PR TITLE
Add a CharRNN autoregressive language model

### DIFF
--- a/molgen/char_rnn.py
+++ b/molgen/char_rnn.py
@@ -1,0 +1,52 @@
+"""Autoregressive RNN language model over SMILES tokens.
+
+A GRU/LSTM that predicts the next token given the prefix -- the classic,
+lightweight, and surprisingly strong baseline for SMILES generation (it is one
+of the reference models in the MOSES benchmark).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class CharRNN(nn.Module):
+    """Next-token RNN language model.
+
+    Operates on ``(batch, seq)`` token-id tensors. Train with teacher forcing:
+    feed ``tokens[:, :-1]`` and predict ``tokens[:, 1:]``.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        embedding_dim: int = 128,
+        hidden_dim: int = 512,
+        num_layers: int = 3,
+        pad_idx: int = 0,
+        dropout: float = 0.2,
+        cell: str = "gru",
+    ):
+        super().__init__()
+        self.cell = cell.lower()
+        if self.cell not in ("gru", "lstm"):
+            raise ValueError(f"cell must be 'gru' or 'lstm', got {cell!r}")
+        self.pad_idx = pad_idx
+        self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=pad_idx)
+        rnn_cls = nn.LSTM if self.cell == "lstm" else nn.GRU
+        self.rnn = rnn_cls(
+            embedding_dim,
+            hidden_dim,
+            num_layers=num_layers,
+            batch_first=True,
+            dropout=dropout if num_layers > 1 else 0.0,
+        )
+        self.fc_out = nn.Linear(hidden_dim, vocab_size)
+
+    def forward(self, x: torch.Tensor, hidden=None):
+        """Return ``(logits, hidden)`` where logits is ``(batch, seq, vocab)``."""
+        embedded = self.embedding(x)
+        output, hidden = self.rnn(embedded, hidden)
+        logits = self.fc_out(output)
+        return logits, hidden

--- a/tests/test_char_rnn.py
+++ b/tests/test_char_rnn.py
@@ -1,0 +1,49 @@
+"""Tests for the CharRNN language model."""
+
+import torch
+import torch.nn.functional as F
+
+from molgen.char_rnn import CharRNN
+
+
+def test_forward_output_shapes_gru():
+    model = CharRNN(vocab_size=20, embedding_dim=16, hidden_dim=32, num_layers=2, pad_idx=0)
+    x = torch.randint(0, 20, (4, 10))
+    logits, hidden = model(x)
+    assert logits.shape == (4, 10, 20)
+    assert hidden is not None
+
+
+def test_forward_works_with_lstm_cell():
+    model = CharRNN(vocab_size=12, embedding_dim=8, hidden_dim=16, num_layers=1, cell="lstm")
+    logits, (h, c) = model(torch.randint(0, 12, (2, 6)))
+    assert logits.shape == (2, 6, 12)
+
+
+def test_invalid_cell_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        CharRNN(vocab_size=10, cell="transformer")
+
+
+def test_can_overfit_a_single_sequence():
+    torch.manual_seed(0)
+    model = CharRNN(
+        vocab_size=10, embedding_dim=16, hidden_dim=32, num_layers=1, pad_idx=0, dropout=0.0
+    )
+    seq = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    first_loss = None
+    last_loss = None
+    for step in range(60):
+        logits, _ = model(seq[:, :-1])
+        loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)), seq[:, 1:].reshape(-1))
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if step == 0:
+            first_loss = loss.item()
+        last_loss = loss.item()
+    # The model should clearly learn to reproduce the fixed sequence.
+    assert last_loss < first_loss * 0.5


### PR DESCRIPTION
Adds the first of the modern generator models: a recurrent SMILES language model.

**`molgen/char_rnn.py`** — `CharRNN`, a next-token GRU/LSTM language model on `(batch, seq)` token ids: padding-aware embedding, configurable `embedding_dim`/`hidden_dim`/`num_layers`/`dropout`, selectable `gru`/`lstm` cell, batch-first. Trained with teacher forcing (`tokens[:, :-1]` → `tokens[:, 1:]`). This is the classic, strong, lightweight SMILES baseline (a MOSES reference model).

**Tests** (`tests/test_char_rnn.py`): forward output shapes for GRU and LSTM, invalid-cell validation, and — as real evidence it learns — an overfit test where the loss on a fixed sequence drops by >2x over 60 steps.

**Validation**: `ruff check` clean; `pytest` green.
