### PR TITLE
Add a MolGPT-style decoder-only Transformer

### DIFF
--- a/molgen/molgpt.py
+++ b/molgen/molgpt.py
@@ -1,0 +1,53 @@
+"""Decoder-only Transformer language model for SMILES (MolGPT-style).
+
+A GPT-style stack: token embedding + positional encoding, a Transformer with
+causal self-attention, then a linear head over the vocabulary. Padding is kept
+at the end of each sequence, so the causal mask alone prevents attending to it.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from molgen.vae import PositionalEncoding
+
+
+class MolGPT(nn.Module):
+    """Autoregressive decoder-only Transformer over SMILES token ids."""
+
+    def __init__(
+        self,
+        vocab_size: int,
+        embedding_dim: int = 256,
+        nhead: int = 8,
+        hidden_dim: int = 1024,
+        num_layers: int = 4,
+        pad_idx: int = 0,
+        dropout: float = 0.1,
+        max_len: int = 512,
+    ):
+        super().__init__()
+        self.pad_idx = pad_idx
+        self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=pad_idx)
+        self.pos_encoder = PositionalEncoding(embedding_dim, max_len=max_len)
+        layer = nn.TransformerEncoderLayer(
+            embedding_dim,
+            nhead,
+            hidden_dim,
+            dropout=dropout,
+            activation="gelu",
+            batch_first=True,
+        )
+        self.transformer = nn.TransformerEncoder(layer, num_layers=num_layers)
+        self.norm = nn.LayerNorm(embedding_dim)
+        self.fc_out = nn.Linear(embedding_dim, vocab_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return next-token logits of shape ``(batch, seq, vocab)``."""
+        seq_len = x.size(1)
+        causal_mask = nn.Transformer.generate_square_subsequent_mask(seq_len, device=x.device)
+        hidden = self.pos_encoder(self.embedding(x))
+        hidden = self.transformer(hidden, mask=causal_mask, is_causal=True)
+        hidden = self.norm(hidden)
+        return self.fc_out(hidden)

--- a/tests/test_molgpt.py
+++ b/tests/test_molgpt.py
@@ -1,0 +1,57 @@
+"""Tests for the MolGPT decoder-only Transformer."""
+
+import torch
+import torch.nn.functional as F
+
+from molgen.molgpt import MolGPT
+
+
+def _tiny_model():
+    return MolGPT(
+        vocab_size=12,
+        embedding_dim=16,
+        nhead=2,
+        hidden_dim=32,
+        num_layers=2,
+        pad_idx=0,
+        dropout=0.0,
+        max_len=64,
+    )
+
+
+def test_forward_output_shape():
+    model = _tiny_model()
+    logits = model(torch.randint(0, 12, (3, 9)))
+    assert logits.shape == (3, 9, 12)
+
+
+def test_attention_is_causal():
+    model = _tiny_model()
+    model.eval()
+    a = torch.tensor([[1, 2, 3, 4, 5, 6]])
+    b = a.clone()
+    b[0, 4:] = torch.tensor([9, 10])  # change only the last two (future) positions
+    with torch.no_grad():
+        out_a = model(a)
+        out_b = model(b)
+    # Predictions for positions 0..3 must not depend on tokens at positions >= 4.
+    assert torch.allclose(out_a[:, :4], out_b[:, :4], atol=1e-5)
+
+
+def test_can_overfit_a_single_sequence():
+    torch.manual_seed(0)
+    model = _tiny_model()
+    seq = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    first_loss = None
+    last_loss = None
+    for step in range(80):
+        logits = model(seq[:, :-1])
+        loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)), seq[:, 1:].reshape(-1))
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if step == 0:
+            first_loss = loss.item()
+        last_loss = loss.item()
+    assert last_loss < first_loss * 0.5


### PR DESCRIPTION
Adds a modern, lightweight decoder-only Transformer generator (MolGPT-style).

**`molgen/molgpt.py`** — `MolGPT`: token embedding + sinusoidal positional encoding → `TransformerEncoder` with a causal mask (`is_causal=True`) → LayerNorm → linear vocabulary head; GELU activations, configurable depth/width/heads. Because padding is always trailing (after EOS), the causal mask alone prevents attending to pad, so no separate padding mask is needed.

**Tests** (`tests/test_molgpt.py`):
- forward output shape;
- **causality** — changing tokens at later positions does not change predictions for earlier positions (`atol=1e-5`); this directly verifies the causal mask;
- **overfit** — loss on a fixed sequence drops >2x, confirming it trains.

**Validation**: `ruff check` clean; `pytest` green.
