### PR TITLE
Add basic generation metrics (validity, uniqueness, novelty, IntDiv)

### DIFF
--- a/molgen/metrics.py
+++ b/molgen/metrics.py
@@ -1,0 +1,78 @@
+"""Distribution-learning metrics for generated molecule sets (MOSES-style).
+
+All functions accept lists of SMILES strings. Validity-dependent metrics
+operate on the canonicalized valid subset, matching the MOSES conventions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rdkit import Chem
+from rdkit.Chem import DataStructs, rdFingerprintGenerator
+
+from molgen.chem import canonicalize_smiles
+
+_MORGAN = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=2048)
+
+
+def _canonical_valid(smiles_list: Sequence[str]) -> list[str]:
+    """Return the canonical SMILES of the valid molecules in the list."""
+    out = []
+    for smiles in smiles_list:
+        canonical = canonicalize_smiles(smiles)
+        if canonical is not None:
+            out.append(canonical)
+    return out
+
+
+def validity(smiles_list: Sequence[str]) -> float:
+    """Fraction of generated strings that are valid molecules."""
+    if not smiles_list:
+        return 0.0
+    return len(_canonical_valid(smiles_list)) / len(smiles_list)
+
+
+def uniqueness(smiles_list: Sequence[str]) -> float:
+    """Fraction of valid molecules that are unique (after canonicalization)."""
+    valid = _canonical_valid(smiles_list)
+    if not valid:
+        return 0.0
+    return len(set(valid)) / len(valid)
+
+
+def novelty(smiles_list: Sequence[str], reference: Sequence[str]) -> float:
+    """Fraction of unique valid molecules not present in the reference set."""
+    generated = set(_canonical_valid(smiles_list))
+    if not generated:
+        return 0.0
+    reference_set = set(_canonical_valid(reference))
+    novel = [s for s in generated if s not in reference_set]
+    return len(novel) / len(generated)
+
+
+def _fingerprints(smiles_list: Sequence[str]):
+    fps = []
+    for smiles in smiles_list:
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is not None:
+            fps.append(_MORGAN.GetFingerprint(mol))
+    return fps
+
+
+def internal_diversity(smiles_list: Sequence[str]) -> float:
+    """Mean pairwise Tanimoto *distance* (1 - similarity) over Morgan fingerprints.
+
+    Higher means a more diverse set. Returns 0.0 for fewer than two molecules.
+    """
+    fps = _fingerprints(smiles_list)
+    n = len(fps)
+    if n < 2:
+        return 0.0
+    total, count = 0.0, 0
+    for i in range(n - 1):
+        sims = DataStructs.BulkTanimotoSimilarity(fps[i], fps[i + 1 :])
+        total += float(sum(sims))
+        count += len(sims)
+    mean_similarity = total / count if count else 0.0
+    return 1.0 - mean_similarity

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,27 @@
+"""Tests for the basic generation metrics."""
+
+from molgen.metrics import internal_diversity, novelty, uniqueness, validity
+
+
+def test_validity_fraction():
+    assert validity(["CCO", "c1ccccc1", "not_valid", "C(C"]) == 0.5
+    assert validity([]) == 0.0
+
+
+def test_uniqueness_dedups_canonically():
+    # "CCO" and "OCC" are the same molecule; 3 valid -> 2 unique.
+    assert uniqueness(["CCO", "OCC", "c1ccccc1"]) == 2 / 3
+
+
+def test_novelty_against_reference():
+    # benzene is novel, ethanol is in the reference.
+    assert novelty(["CCO", "c1ccccc1"], reference=["CCO"]) == 0.5
+
+
+def test_internal_diversity_in_unit_range():
+    div = internal_diversity(["CCO", "c1ccccc1", "CCCCCC", "CC(=O)O"])
+    assert 0.0 <= div <= 1.0
+
+
+def test_internal_diversity_zero_for_identical():
+    assert internal_diversity(["CCO", "CCO", "CCO"]) < 1e-6


### PR DESCRIPTION
Adds the core evaluation metrics used to judge molecular generators (the MOSES "basic" set).

**`molgen/metrics.py`**
- `validity` — fraction of generated strings RDKit can parse.
- `uniqueness` — fraction of *valid* molecules that are distinct after canonicalization.
- `novelty` — fraction of unique valid molecules not present in a reference (training) set.
- `internal_diversity` — mean pairwise Tanimoto *distance* over Morgan fingerprints (modern `rdFingerprintGenerator` API), i.e. how varied the set is.

All validity-dependent metrics operate on the canonicalized valid subset, following MOSES conventions.

**Tests** (`tests/test_metrics.py`): exact expected values for validity (0.5), canonical uniqueness (2/3), novelty (0.5), IntDiv in [0,1], and ~0 diversity for identical molecules.

**Validation**: `ruff check` clean; `pytest` green.
