### PR TITLE
Add molecular property metrics (QED, logP, MW, SA score)

### DIFF
--- a/molgen/properties.py
+++ b/molgen/properties.py
@@ -1,0 +1,69 @@
+"""Molecular property calculators: QED, logP, molecular weight, SA score.
+
+Each function returns ``None`` for unparseable SMILES. Synthetic accessibility
+uses the Ertl SA scorer that ships with RDKit's contrib modules; if it is
+unavailable on a given install, ``sa_score`` returns ``None``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Sequence
+from statistics import mean
+
+from rdkit import Chem
+from rdkit.Chem import QED, Crippen, Descriptors, RDConfig
+
+try:
+    sys.path.append(os.path.join(RDConfig.RDContribDir, "SA_Score"))
+    import sascorer  # noqa: E402
+
+    _HAS_SA = True
+except Exception:  # pragma: no cover - depends on the RDKit build
+    _HAS_SA = False
+
+
+def _mol(smiles: str):
+    return Chem.MolFromSmiles(smiles)
+
+
+def qed(smiles: str) -> float | None:
+    """Quantitative Estimate of Drug-likeness, in [0, 1]."""
+    mol = _mol(smiles)
+    return None if mol is None else QED.qed(mol)
+
+
+def logp(smiles: str) -> float | None:
+    """Crippen octanol-water partition coefficient (logP)."""
+    mol = _mol(smiles)
+    return None if mol is None else Crippen.MolLogP(mol)
+
+
+def molecular_weight(smiles: str) -> float | None:
+    """Average molecular weight."""
+    mol = _mol(smiles)
+    return None if mol is None else Descriptors.MolWt(mol)
+
+
+def sa_score(smiles: str) -> float | None:
+    """Ertl synthetic-accessibility score, ~1 (easy) to ~10 (hard)."""
+    mol = _mol(smiles)
+    if mol is None or not _HAS_SA:
+        return None
+    return sascorer.calculateScore(mol)
+
+
+def property_summary(smiles_list: Sequence[str]) -> dict[str, float]:
+    """Mean of each property over the valid molecules in the list."""
+    calculators = {
+        "qed": qed,
+        "logp": logp,
+        "mol_weight": molecular_weight,
+        "sa_score": sa_score,
+    }
+    summary: dict[str, float] = {}
+    for name, fn in calculators.items():
+        values = [v for s in smiles_list if (v := fn(s)) is not None]
+        summary[name] = mean(values) if values else float("nan")
+    return summary

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,31 @@
+"""Tests for molecular property calculators."""
+
+from molgen.properties import logp, molecular_weight, property_summary, qed, sa_score
+
+ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
+
+
+def test_qed_logp_mw_for_aspirin():
+    assert 0.0 <= qed(ASPIRIN) <= 1.0
+    assert abs(molecular_weight(ASPIRIN) - 180.16) < 0.5
+    assert isinstance(logp(ASPIRIN), float)
+
+
+def test_properties_none_for_invalid():
+    assert qed("nope$$") is None
+    assert logp("nope$$") is None
+    assert molecular_weight("nope$$") is None
+    assert sa_score("nope$$") is None
+
+
+def test_sa_score_in_expected_range():
+    score = sa_score("CCO")
+    if score is not None:  # SA scorer ships with RDKit contrib
+        assert 1.0 <= score <= 10.0
+
+
+def test_property_summary_keys_and_ranges():
+    summary = property_summary(["CCO", "c1ccccc1", "nope$$"])
+    assert {"qed", "logp", "mol_weight", "sa_score"} <= set(summary)
+    assert 0.0 <= summary["qed"] <= 1.0
+    assert summary["mol_weight"] > 0


### PR DESCRIPTION
Adds the per-molecule property metrics commonly reported for de novo generation.

**`molgen/properties.py`**
- `qed` — Quantitative Estimate of Drug-likeness (0–1).
- `logp` — Crippen octanol–water logP.
- `molecular_weight` — average MW.
- `sa_score` — Ertl synthetic accessibility (~1 easy … ~10 hard), via RDKit's bundled `SA_Score` contrib (guarded: returns `None` if a given RDKit build lacks it).
- `property_summary(smiles_list)` — mean of each property over the valid molecules.

Invalid SMILES return `None`.

**Tests** (`tests/test_properties.py`): aspirin QED/MW/logP sanity, `None` on invalid input, SA score in [1, 10], and `property_summary` keys/ranges.

**Validation**: `ruff check` clean; `pytest` green.
