### PR TITLE
Add scaffold diversity and nearest-neighbour similarity metrics

### DIFF
--- a/molgen/metrics.py
+++ b/molgen/metrics.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 
 from rdkit import Chem
 from rdkit.Chem import DataStructs, rdFingerprintGenerator
+from rdkit.Chem.Scaffolds import MurckoScaffold
 
 from molgen.chem import canonicalize_smiles
 
@@ -76,3 +77,33 @@ def internal_diversity(smiles_list: Sequence[str]) -> float:
         count += len(sims)
     mean_similarity = total / count if count else 0.0
     return 1.0 - mean_similarity
+
+
+def _scaffold(smiles: str) -> str | None:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    return MurckoScaffold.MurckoScaffoldSmiles(mol=mol)
+
+
+def unique_scaffolds(smiles_list: Sequence[str]) -> float:
+    """Fraction of distinct Bemis-Murcko scaffolds among the valid molecules."""
+    scaffolds = [s for s in (_scaffold(smi) for smi in smiles_list) if s is not None]
+    if not scaffolds:
+        return 0.0
+    return len(set(scaffolds)) / len(scaffolds)
+
+
+def snn(smiles_list: Sequence[str], reference: Sequence[str]) -> float:
+    """Mean similarity-to-nearest-neighbour (Tanimoto) from generated to reference.
+
+    For each generated molecule, take the maximum Tanimoto similarity to any
+    reference molecule, then average. High SNN with low novelty can indicate
+    memorisation of the training set.
+    """
+    gen_fps = _fingerprints(smiles_list)
+    ref_fps = _fingerprints(reference)
+    if not gen_fps or not ref_fps:
+        return 0.0
+    total = sum(max(DataStructs.BulkTanimotoSimilarity(fp, ref_fps)) for fp in gen_fps)
+    return total / len(gen_fps)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,15 @@
 """Tests for the basic generation metrics."""
 
-from molgen.metrics import internal_diversity, novelty, uniqueness, validity
+import pytest
+
+from molgen.metrics import (
+    internal_diversity,
+    novelty,
+    snn,
+    unique_scaffolds,
+    uniqueness,
+    validity,
+)
 
 
 def test_validity_fraction():
@@ -25,3 +34,18 @@ def test_internal_diversity_in_unit_range():
 
 def test_internal_diversity_zero_for_identical():
     assert internal_diversity(["CCO", "CCO", "CCO"]) < 1e-6
+
+
+def test_unique_scaffolds_shares_benzene_ring():
+    # Benzene and toluene have the same Bemis-Murcko scaffold (benzene).
+    assert unique_scaffolds(["c1ccccc1", "Cc1ccccc1"]) == 0.5
+
+
+def test_snn_is_one_against_itself():
+    molecules = ["c1ccccc1", "CCO", "CC(=O)O"]
+    assert snn(molecules, molecules) == pytest.approx(1.0)
+
+
+def test_snn_lower_for_dissimilar_reference():
+    similarity = snn(["c1ccccc1"], ["CCCCCCCCCC"])  # benzene vs. decane
+    assert similarity < 0.5


### PR DESCRIPTION
Adds two more MOSES-style distribution metrics, keeping to lightweight RDKit computations.

**Added to `molgen/metrics.py`**
- `unique_scaffolds` — fraction of distinct **Bemis-Murcko scaffolds** among valid molecules (structural diversity at the scaffold level).
- `snn` — mean **similarity-to-nearest-neighbour**: for each generated molecule, its max Tanimoto similarity to the reference set, averaged. High SNN with low novelty is a memorisation signal.

FCD (Fréchet ChemNet Distance) is intentionally **not** included: it needs a heavy pretrained ChemNet model, which conflicts with the project's lightweight goal.

**Tests**: benzene/toluene share a scaffold (→ 0.5), SNN against itself is 1.0, and SNN of benzene vs. decane is low.

**Validation**: `ruff check` clean; `pytest` green.
