### PR TITLE
Add an aggregate MOSES-style evaluation report

### DIFF
--- a/molgen/metrics.py
+++ b/molgen/metrics.py
@@ -13,6 +13,7 @@ from rdkit.Chem import DataStructs, rdFingerprintGenerator
 from rdkit.Chem.Scaffolds import MurckoScaffold
 
 from molgen.chem import canonicalize_smiles
+from molgen.properties import property_summary
 
 _MORGAN = rdFingerprintGenerator.GetMorganGenerator(radius=2, fpSize=2048)
 
@@ -107,3 +108,27 @@ def snn(smiles_list: Sequence[str], reference: Sequence[str]) -> float:
         return 0.0
     total = sum(max(DataStructs.BulkTanimotoSimilarity(fp, ref_fps)) for fp in gen_fps)
     return total / len(gen_fps)
+
+
+def evaluate_generation(
+    smiles_list: Sequence[str], reference: Sequence[str] | None = None
+) -> dict:
+    """Compute a MOSES-style report for a set of generated SMILES.
+
+    Includes validity, uniqueness, internal diversity, unique-scaffold fraction,
+    and mean physico-chemical properties. When a ``reference`` (e.g. the training
+    set) is given, novelty and SNN are added. Internal-diversity / SNN are O(n^2)
+    in the set size, so pass a manageable sample for large runs.
+    """
+    report: dict = {
+        "n_generated": len(smiles_list),
+        "validity": validity(smiles_list),
+        "uniqueness": uniqueness(smiles_list),
+        "internal_diversity": internal_diversity(smiles_list),
+        "unique_scaffolds": unique_scaffolds(smiles_list),
+        "properties": property_summary(smiles_list),
+    }
+    if reference is not None:
+        report["novelty"] = novelty(smiles_list, reference)
+        report["snn"] = snn(smiles_list, reference)
+    return report

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,6 +3,7 @@
 import pytest
 
 from molgen.metrics import (
+    evaluate_generation,
     internal_diversity,
     novelty,
     snn,
@@ -49,3 +50,19 @@ def test_snn_is_one_against_itself():
 def test_snn_lower_for_dissimilar_reference():
     similarity = snn(["c1ccccc1"], ["CCCCCCCCCC"])  # benzene vs. decane
     assert similarity < 0.5
+
+
+def test_evaluate_generation_report_structure():
+    generated = ["CCO", "c1ccccc1", "CC(=O)O", "invalid$$"]
+    report = evaluate_generation(generated, reference=["CCO"])
+    assert report["n_generated"] == 4
+    assert report["validity"] == 0.75
+    for key in ("uniqueness", "internal_diversity", "unique_scaffolds", "novelty", "snn"):
+        assert key in report
+    assert "qed" in report["properties"]
+
+
+def test_evaluate_generation_without_reference_omits_novelty():
+    report = evaluate_generation(["CCO", "c1ccccc1"])
+    assert "novelty" not in report
+    assert "snn" not in report


### PR DESCRIPTION
Ties the individual metrics into one call so evaluating a generated set is a one-liner.

**`evaluate_generation(smiles_list, reference=None)`** returns a report dict with:
- `n_generated`, `validity`, `uniqueness`, `internal_diversity`, `unique_scaffolds`
- mean physico-chemical `properties` (QED / logP / MW / SA)
- `novelty` and `snn` **when a reference set is given** (e.g. the training data)

Documents that internal-diversity/SNN are O(n²), so callers sample for large runs.

**Tests**: report structure + exact validity (0.75) on a mixed set, and that novelty/SNN are omitted without a reference.

**Validation**: `ruff check` clean; `pytest` → 70 passed.
