### PR TITLE
Add model + tokenizer checkpointing

### DIFF
--- a/molgen/checkpoint.py
+++ b/molgen/checkpoint.py
@@ -1,0 +1,50 @@
+"""Save and load model + tokenizer checkpoints in a single file.
+
+A checkpoint stores the model kind and constructor kwargs, its state dict, and
+the tokenizer kind and vocabulary, so a trained generator can be fully
+reconstructed for inference without re-specifying the architecture.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from molgen.char_rnn import CharRNN
+from molgen.molgpt import MolGPT
+from molgen.tokenizers import SmilesTokenizer
+
+_MODELS = {"charrnn": CharRNN, "molgpt": MolGPT}
+
+
+def _tokenizer_kind(tokenizer) -> str:
+    return "selfies" if type(tokenizer).__name__ == "SelfiesTokenizer" else "smiles"
+
+
+def save_checkpoint(path, model, model_kind: str, model_kwargs: dict, tokenizer) -> None:
+    """Save model architecture/state and tokenizer vocabulary to ``path``."""
+    if model_kind not in _MODELS:
+        raise ValueError(f"unknown model_kind {model_kind!r}; expected one of {list(_MODELS)}")
+    torch.save(
+        {
+            "model_kind": model_kind,
+            "model_kwargs": model_kwargs,
+            "model_state": model.state_dict(),
+            "tokenizer_kind": _tokenizer_kind(tokenizer),
+            "vocab": list(tokenizer.itos),
+        },
+        path,
+    )
+
+
+def load_checkpoint(path, device=None):
+    """Reconstruct ``(model, tokenizer)`` from a checkpoint saved by save_checkpoint."""
+    ckpt = torch.load(path, map_location=device or "cpu", weights_only=False)
+    if ckpt["tokenizer_kind"] == "selfies":
+        from molgen.selfies_tokenizer import SelfiesTokenizer
+
+        tokenizer = SelfiesTokenizer(ckpt["vocab"])
+    else:
+        tokenizer = SmilesTokenizer(ckpt["vocab"])
+    model = _MODELS[ckpt["model_kind"]](**ckpt["model_kwargs"])
+    model.load_state_dict(ckpt["model_state"])
+    return model, tokenizer

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,40 @@
+"""Tests for model + tokenizer checkpointing."""
+
+import torch
+
+from molgen.char_rnn import CharRNN
+from molgen.checkpoint import load_checkpoint, save_checkpoint
+from molgen.data import load_sample_smiles
+from molgen.tokenizers import SmilesTokenizer
+
+
+def test_checkpoint_roundtrip_reproduces_outputs(tmp_path):
+    tok = SmilesTokenizer.from_smiles(load_sample_smiles()[:50])
+    kwargs = dict(
+        vocab_size=tok.vocab_size, embedding_dim=16, hidden_dim=32, num_layers=1, pad_idx=tok.pad_id
+    )
+    model = CharRNN(**kwargs)
+    model.eval()
+    x = torch.tensor([[tok.bos_id, 5, 6, 7]])
+    with torch.no_grad():
+        before = model(x)[0]
+
+    path = tmp_path / "model.pt"
+    save_checkpoint(path, model, "charrnn", kwargs, tok)
+    model2, tok2 = load_checkpoint(path)
+    model2.eval()
+    with torch.no_grad():
+        after = model2(x)[0]
+
+    assert torch.allclose(before, after)
+    assert tok2.itos == tok.itos
+    assert tok2.vocab_size == tok.vocab_size
+
+
+def test_save_checkpoint_rejects_unknown_model(tmp_path):
+    import pytest
+
+    tok = SmilesTokenizer.from_smiles(["CCO"])
+    model = CharRNN(vocab_size=tok.vocab_size, pad_idx=tok.pad_id)
+    with pytest.raises(ValueError):
+        save_checkpoint(tmp_path / "m.pt", model, "diffusion", {}, tok)


### PR DESCRIPTION
Adds portable checkpointing so trained models can be saved and reloaded for inference (and used by the upcoming CLI).

**`molgen/checkpoint.py`**
- `save_checkpoint(path, model, model_kind, model_kwargs, tokenizer)` — stores model kind + constructor kwargs + `state_dict`, and the tokenizer kind + `vocab`.
- `load_checkpoint(path, device)` — rebuilds the tokenizer (SMILES or SELFIES) and the model (CharRNN or MolGPT), loads weights, and returns `(model, tokenizer)` ready for sampling.

**Tests**: a round-trip where the reloaded model reproduces the original outputs (and the vocab matches), plus rejection of an unknown model kind.

**Validation**: `ruff check` clean; `pytest` → 72 passed.
