### PR TITLE
Mark the package as typed (PEP 561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ molgen = "molgen.cli:main"
 include = ["molgen*"]
 
 [tool.setuptools.package-data]
+"molgen" = ["py.typed"]
 "molgen.datasets" = ["*.smi"]
 
 [tool.ruff]


### PR DESCRIPTION
Marks `molgen` as a typed package (PEP 561).

The modules carry inline type annotations, but without a `py.typed` marker downstream type checkers ignore them. This adds `molgen/py.typed` and ships it via `package-data`, so `mypy`/`pyright` pick up the annotations when `molgen` is used as a dependency.

`ruff` clean; `pytest` → 74 passed.
