### PR TITLE
Apply ruff format to fix the CI format check

### DIFF
--- a/molgen/metrics.py
+++ b/molgen/metrics.py
@@ -110,9 +110,7 @@ def snn(smiles_list: Sequence[str], reference: Sequence[str]) -> float:
     return total / len(gen_fps)
 
 
-def evaluate_generation(
-    smiles_list: Sequence[str], reference: Sequence[str] | None = None
-) -> dict:
+def evaluate_generation(smiles_list: Sequence[str], reference: Sequence[str] | None = None) -> dict:
     """Compute a MOSES-style report for a set of generated SMILES.
 
     Includes validity, uniqueness, internal diversity, unique-scaffold fraction,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,14 +22,22 @@ def test_train_then_sample_roundtrip(tmp_path):
     main(
         [
             "train",
-            "--data", str(data),
-            "--model", "charrnn",
-            "--epochs", "1",
-            "--batch-size", "8",
-            "--embedding-dim", "16",
-            "--hidden-dim", "32",
-            "--num-layers", "1",
-            "--out", str(checkpoint),
+            "--data",
+            str(data),
+            "--model",
+            "charrnn",
+            "--epochs",
+            "1",
+            "--batch-size",
+            "8",
+            "--embedding-dim",
+            "16",
+            "--hidden-dim",
+            "32",
+            "--num-layers",
+            "1",
+            "--out",
+            str(checkpoint),
         ]
     )
     assert checkpoint.exists()
@@ -38,10 +46,14 @@ def test_train_then_sample_roundtrip(tmp_path):
     main(
         [
             "sample",
-            "--checkpoint", str(checkpoint),
-            "--num", "5",
-            "--max-len", "20",
-            "--out", str(generated),
+            "--checkpoint",
+            str(checkpoint),
+            "--num",
+            "5",
+            "--max-len",
+            "20",
+            "--out",
+            str(generated),
         ]
     )
     assert len(generated.read_text(encoding="utf-8").splitlines()) == 5


### PR DESCRIPTION
Two files (molgen/metrics.py from the evaluate-report PR, tests/test_cli.py from the CLI PR) had formatting that `ruff check` accepted but `ruff format --check` did not, which turned the CI format step red on main. This runs `ruff format` on them. No logic changes.

All three CI checks now pass locally: `ruff check`, `ruff format --check`, and `pytest` (74 passed).