### PR TITLE
Update GitHub Actions to checkout@v6 and setup-python@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
Bumps the CI workflow to the current major versions of actions/checkout and actions/setup-python, which run on Node 24 and clear the Node 20 deprecation warning on the runners.