### PR TITLE
Update project description and add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "molgen: a lightweight toolkit for de novo molecular generation"
+abstract: >-
+  A lightweight, modern toolkit for de novo molecular generation with deep
+  sequence models: atom-level SMILES and SELFIES tokenizers, CharRNN / MolGPT /
+  VAE generators, a mixed-precision training loop, configurable sampling, and a
+  MOSES-style evaluation suite.
+authors:
+  - family-names: Li
+    given-names: Daoyuan
+repository-code: "https://github.com/DaoyuanLi2816/Molecule-Generator"
+license: MIT
+keywords:
+  - molecular-generation
+  - cheminformatics
+  - deep-learning
+  - SMILES
+  - SELFIES
+  - generative-model

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ SMILES mode tends to learn the data distribution more faithfully.
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). Please run
 `ruff check .`, `ruff format .`, and `pytest` before opening a pull request.
 
+## Citation
+
+If you use this toolkit in your work, please cite it via the **Cite this
+repository** button on GitHub (metadata in [`CITATION.cff`](CITATION.cff)).
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/molgen/__init__.py
+++ b/molgen/__init__.py
@@ -1,6 +1,8 @@
-"""molgen: a lightweight VAE-based molecular SMILES string generator.
+"""molgen: a lightweight toolkit for de novo molecular generation.
 
-See https://github.com/DaoyuanLi2816/Molecule-Generator for documentation.
+Provides SMILES and SELFIES tokenizers, CharRNN / MolGPT / VAE models, a
+mixed-precision training loop, configurable sampling, and a MOSES-style metric
+suite. See https://github.com/DaoyuanLi2816/Molecule-Generator for documentation.
 """
 
 from importlib.metadata import PackageNotFoundError, version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molgen"
 version = "0.1.0"
-description = "A lightweight VAE-based molecular SMILES string generator"
+description = "A lightweight toolkit for de novo molecular generation (SMILES/SELFIES; CharRNN, MolGPT, VAE)"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }


### PR DESCRIPTION
Brings the project's self-description in line with what it actually is, and adds citation metadata.

- **Descriptions**: `pyproject.toml` and `molgen/__init__.py` still said "VAE-based molecular SMILES string generator". Updated both to "a lightweight toolkit for de novo molecular generation (SMILES/SELFIES; CharRNN, MolGPT, VAE)".
- **`CITATION.cff`**: standard CFF 1.2.0 metadata so GitHub renders a *Cite this repository* button.
- **README**: a short Citation section.

The GitHub repository **About** description and **topics** were also refreshed to match (repo settings, not part of this diff).

`ruff check`, `ruff format --check`, and `pytest` pass; CITATION.cff validated as YAML.
