### PR TITLE
Add PyPI badge and trusted-publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release to PyPI
+
+# Publishes to PyPI when a GitHub release is published.
+# Uses PyPI trusted publishing (no token stored in the repo):
+# https://docs.pypi.org/trusted-publishers/ — register this repo + workflow
+# under the molgen project on PyPI once.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: |
+          python -m pip install build
+          python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <div align="center">
 
 [![CI](https://github.com/DaoyuanLi2816/Molecule-Generator/actions/workflows/ci.yml/badge.svg)](https://github.com/DaoyuanLi2816/Molecule-Generator/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/molgen)](https://pypi.org/project/molgen/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
`molgen` 0.1.0 is now [live on PyPI](https://pypi.org/project/molgen/0.1.0/) (`pip install molgen` — the bare name was still free). This PR adds:

- the PyPI version badge to the masthead
- `.github/workflows/release.yml`: build + publish via [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) on GitHub release, matching the other five repos (uses checkout@v6 / setup-python@v6 like ci.yml). Registering the publisher on PyPI is a one-time UI step; until then releases can keep using twine.

Tagged `v0.1.0` at the published commit. Repo homepage now points at the PyPI page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)