### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/molgen/__init__.py
+++ b/molgen/__init__.py
@@ -10,6 +10,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("molgen")
 except PackageNotFoundError:  # pragma: no cover - running from a source checkout
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "molgen"
-version = "0.1.0"
+version = "0.1.1"
 description = "A lightweight toolkit for de novo molecular generation (SMILES/SELFIES; CharRNN, MolGPT, VAE)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Docs-only patch release: the PyPI page picks up the post-rename project URLs (`DaoyuanLi2816/molgen`) and the banner masthead README. No code changes.

First release published through the newly registered PyPI trusted publisher (`release.yml`), replacing token-based twine uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)