### PR TITLE
Make BetaTCVAE a classic sentence VAE (one fixed-size latent per molecule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Changed
+- `BetaTCVAE` is now a **sentence VAE**: a molecule is encoded to a single
+  fixed-size latent vector (masked mean-pool of the encoder states) rather than
+  a per-position latent, so each molecule is one point in latent space — the
+  natural setting for nearby sampling and interpolation. `latent_dim` is now
+  independent of `embedding_dim` (the latent is projected back up before
+  decoding), so it can act as a genuine bottleneck; `vae-train` gains a
+  `--latent-dim` flag. This also removes the decoder's cross-attention memory,
+  so generation and interpolation no longer differ in how they mask it.
 - The VAE latent-space workflow now uses the shared toolkit tokenizers instead
   of a private 4-character toy tokenizer, so it works on arbitrary molecules
   (not just the synthetic C/O/ring dataset). `SelfiesTokenizer` is the default,

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ property space. Generation can be steered toward a target, not just imitated:
 |-------|--------|-------------|
 | `CharRNN` | `molgen.char_rnn` | GRU/LSTM next-token language model (classic strong baseline) |
 | `MolGPT` | `molgen.molgpt` | Decoder-only Transformer with causal attention |
-| `BetaTCVAE` | `molgen.vae` | Transformer VAE for reconstruction and latent interpolation |
+| `BetaTCVAE` | `molgen.vae` | Sentence VAE (one fixed-size latent per molecule) for reconstruction, nearby sampling, and interpolation |
 
 Both `CharRNN` and `MolGPT` train and sample through the same trainer/sampler.
 

--- a/molgen/cli.py
+++ b/molgen/cli.py
@@ -122,7 +122,7 @@ def cmd_vae_train(args: argparse.Namespace) -> None:
         vocab_size=tokenizer.vocab_size,
         embedding_dim=args.embedding_dim,
         hidden_dim=args.hidden_dim,
-        latent_dim=args.embedding_dim,
+        latent_dim=args.latent_dim,
         nhead=args.nhead,
         num_layers=args.num_layers,
         pad_idx=tokenizer.pad_id,
@@ -232,6 +232,7 @@ def build_parser() -> argparse.ArgumentParser:
     vae_train.add_argument("--batch-size", type=int, default=64)
     vae_train.add_argument("--lr", type=float, default=1e-3)
     vae_train.add_argument("--embedding-dim", type=int, default=64)
+    vae_train.add_argument("--latent-dim", type=int, default=32)
     vae_train.add_argument("--hidden-dim", type=int, default=256)
     vae_train.add_argument("--num-layers", type=int, default=2)
     vae_train.add_argument("--nhead", type=int, default=4)

--- a/molgen/generate.py
+++ b/molgen/generate.py
@@ -45,17 +45,16 @@ def generate_nearby_smiles(
     """
     model.eval()
     seed_ids = torch.tensor([tokenizer.encode(smiles, max_len=max_len)], device=device)
-    pad_mask = seed_ids == tokenizer.pad_id
 
     with torch.no_grad():
-        memory, mu = model.encode(seed_ids)
+        mu, _ = model.encode(seed_ids)  # single latent vector for the seed
         seed_canon = canonicalize_smiles(smiles)
         results = set()
         for i in range(num_samples):
             direction = torch.randn_like(mu)
             direction = direction / direction.norm()
             z = mu + distance_multiplier * (i + 1) * direction
-            logits = model.decode_logits(z, memory, memory_pad_mask=pad_mask)
+            logits = model.decode(z, max_len)
             probs = torch.softmax(logits.squeeze(0) / temperature, dim=-1)
             ids = torch.multinomial(probs, 1).flatten().tolist()
             canon = canonicalize_smiles(tokenizer.decode(ids))

--- a/molgen/interpolate.py
+++ b/molgen/interpolate.py
@@ -40,16 +40,15 @@ def interpolate_smiles(
     ids_2 = torch.tensor([tokenizer.encode(smiles_2, max_len=max_len)], device=device)
 
     with torch.no_grad():
-        memory_1, mu_1 = model.encode(ids_1)
-        memory_2, mu_2 = model.encode(ids_2)
-        memory = (memory_1 + memory_2) / 2
+        mu_1, _ = model.encode(ids_1)  # single latent vector per endpoint
+        mu_2, _ = model.encode(ids_2)
 
         path = []
         seen = set()
         for i in range(num_steps + 1):
             alpha = i / num_steps
             z = mu_1 * (1 - alpha) + mu_2 * alpha
-            logits = model.decode_logits(z, memory)
+            logits = model.decode(z, max_len)
             probs = torch.softmax(logits.squeeze(0) / temperature, dim=-1)
             ids = torch.multinomial(probs, 1).flatten().tolist()
             canon = canonicalize_smiles(tokenizer.decode(ids))

--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -1,10 +1,11 @@
 """Transformer beta-TC-VAE for reconstruction and latent-space exploration.
 
-The VAE encodes a (padded) token sequence to a per-position latent and decodes
-it back through a Transformer decoder. Unlike the autoregressive `CharRNN` /
-`MolGPT` models, it supports *latent-space* operations — sampling molecules
-near a seed and interpolating between two molecules — see
-:mod:`molgen.generate` and :mod:`molgen.interpolate`.
+This is a *sentence* VAE: each molecule is encoded to a single fixed-size latent
+vector (a masked mean-pool over the encoder states), so a molecule corresponds
+to one point in latent space. Unlike the autoregressive `CharRNN` / `MolGPT`
+models, it supports *latent-space* operations — sampling molecules near a seed
+and interpolating between two molecules — see :mod:`molgen.generate` and
+:mod:`molgen.interpolate`.
 
 Tokenization goes through the shared toolkit tokenizers
 (:class:`molgen.selfies_tokenizer.SelfiesTokenizer` is recommended, since its
@@ -48,17 +49,22 @@ class PositionalEncoding(nn.Module):
 
 
 class BetaTCVAE(nn.Module):
-    """Transformer beta-TC-VAE with a per-position latent.
+    """Transformer beta-TC-VAE with a single fixed-size latent per molecule.
+
+    The encoder maps a token sequence to one latent vector (masked mean-pool of
+    the encoder states); the decoder broadcasts that vector across positions,
+    adds positional encodings, and predicts every token in parallel. ``latent_dim``
+    is independent of ``embedding_dim`` — the latent is projected back up to the
+    model width before decoding, so the latent acts as a genuine bottleneck.
 
     Args:
         vocab_size: Tokenizer vocabulary size.
-        embedding_dim: Token embedding width. Must equal ``latent_dim`` because
-            the decoder consumes the latent ``z`` directly as its target stream.
+        embedding_dim: Token embedding / model width.
         hidden_dim: Transformer feed-forward width.
-        latent_dim: Latent width (kept equal to ``embedding_dim``).
+        latent_dim: Latent vector width (the molecule embedding).
         nhead: Number of attention heads.
         num_layers: Number of encoder/decoder layers.
-        pad_idx: Padding token id (masked out of attention and the loss).
+        pad_idx: Padding token id (masked out of attention, pooling, and loss).
         device: Device used for the reparameterization noise.
     """
 
@@ -66,12 +72,6 @@ class BetaTCVAE(nn.Module):
         self, vocab_size, embedding_dim, hidden_dim, latent_dim, nhead, num_layers, pad_idx, device
     ):
         super().__init__()
-        if latent_dim != embedding_dim:
-            raise ValueError(
-                f"latent_dim ({latent_dim}) must equal embedding_dim ({embedding_dim}); "
-                "the decoder consumes the latent directly as its target stream."
-            )
-
         self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=pad_idx)
         self.pos_encoder = PositionalEncoding(embedding_dim)
         self.encoder = nn.TransformerEncoder(
@@ -81,8 +81,12 @@ class BetaTCVAE(nn.Module):
         self.mu = nn.Linear(embedding_dim, latent_dim)
         self.log_var = nn.Linear(embedding_dim, latent_dim)
 
-        self.decoder = nn.TransformerDecoder(
-            nn.TransformerDecoderLayer(embedding_dim, nhead, hidden_dim, batch_first=True),
+        # Decoder: project the latent back to model width, broadcast across
+        # positions, and refine with self-attention (no encoder cross-attention,
+        # so there is no source memory / memory mask).
+        self.latent_to_hidden = nn.Linear(latent_dim, embedding_dim)
+        self.decoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(embedding_dim, nhead, hidden_dim, batch_first=True),
             num_layers=num_layers,
         )
         self.fc_out = nn.Linear(embedding_dim, vocab_size)
@@ -96,34 +100,27 @@ class BetaTCVAE(nn.Module):
         return mu + eps * std
 
     def encode(self, x):
-        """Encode token ids to ``(memory, mu)``.
+        """Encode token ids to ``(mu, log_var)``, each of shape ``(batch, latent)``.
 
-        ``memory`` is the encoder output consumed by the decoder; ``mu`` is the
-        latent mean. Both have shape ``(batch, seq, dim)``. Padding positions
-        are masked out of attention.
+        Padding positions are masked out of both attention and the mean-pool, so
+        the latent reflects only real tokens.
         """
         pad_mask = x == self.pad_idx
-        embedded = self.pos_encoder(self.embedding(x))
-        memory = self.encoder(embedded, src_key_padding_mask=pad_mask)
-        return memory, self.mu(memory)
+        h = self.encoder(self.pos_encoder(self.embedding(x)), src_key_padding_mask=pad_mask)
+        weights = (~pad_mask).unsqueeze(-1).float()  # (batch, seq, 1)
+        pooled = (h * weights).sum(dim=1) / weights.sum(dim=1).clamp(min=1.0)  # (batch, dim)
+        return self.mu(pooled), self.log_var(pooled)
 
-    def decode_logits(self, z, memory, memory_pad_mask=None):
-        """Decode a latent ``z`` against encoder ``memory`` to vocab logits."""
-        decoded = self.decoder(z, memory, memory_key_padding_mask=memory_pad_mask)
-        return self.fc_out(decoded)
+    def decode(self, z, seq_len):
+        """Decode a latent ``z`` (batch, latent) to vocab logits (batch, seq_len, vocab)."""
+        hidden = self.latent_to_hidden(z).unsqueeze(1).expand(-1, seq_len, -1)
+        hidden = self.pos_encoder(hidden)
+        return self.fc_out(self.decoder(hidden))
 
     def forward(self, x):
-        pad_mask = x == self.pad_idx
-        memory, mu = self.encode(x)
-        log_var = self.log_var(memory)
+        mu, log_var = self.encode(x)
         z = self.reparameterize(mu, log_var)
-        decoded = self.decoder(
-            z,
-            memory,
-            tgt_key_padding_mask=pad_mask,
-            memory_key_padding_mask=pad_mask,
-        )
-        return self.fc_out(decoded), mu, log_var
+        return self.decode(z, x.size(1)), mu, log_var
 
 
 def loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=-100):
@@ -199,12 +196,11 @@ def main():
     tokenizer = SelfiesTokenizer.from_smiles(smiles)
     data = tokenizer.encode_batch(smiles, max_len=None)
 
-    embedding_dim = latent_dim = 64
     model_kwargs = dict(
         vocab_size=tokenizer.vocab_size,
-        embedding_dim=embedding_dim,
+        embedding_dim=64,
         hidden_dim=256,
-        latent_dim=latent_dim,
+        latent_dim=32,
         nhead=4,
         num_layers=2,
         pad_idx=tokenizer.pad_id,

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -1,6 +1,5 @@
 """Tests for the BetaTCVAE model and loss."""
 
-import pytest
 import torch
 
 from molgen.vae import BetaTCVAE, PositionalEncoding, loss_function, masked_token_accuracy
@@ -25,8 +24,9 @@ def test_forward_output_shapes():
     x = torch.randint(0, 6, (batch, seq))
     out, mu, log_var = model(x)
     assert out.shape == (batch, seq, 6)
-    assert mu.shape == (batch, seq, 16)
-    assert log_var.shape == (batch, seq, 16)
+    # One fixed-size latent vector per molecule (not per position).
+    assert mu.shape == (batch, 16)
+    assert log_var.shape == (batch, 16)
 
 
 def test_loss_is_finite_scalar():
@@ -51,8 +51,8 @@ def test_backward_pass_populates_gradients():
 def test_loss_ignores_pad_positions():
     # Targets at positions 2, 3, 4 are padding (pad_idx=4).
     x = torch.tensor([[0, 1, 4, 4, 4]])
-    mu = torch.zeros(1, 5, 4)
-    log_var = torch.zeros(1, 5, 4)
+    mu = torch.zeros(1, 4)
+    log_var = torch.zeros(1, 4)
     recon_a = torch.randn(1, 5, 6)
     recon_b = recon_a.clone()
     # Change the logits only at the padding positions.
@@ -105,6 +105,10 @@ def test_positional_encoding_is_position_dependent():
     assert not torch.allclose(out[0, 0], out[0, 1])
 
 
-def test_latent_dim_must_equal_embedding_dim():
-    with pytest.raises(ValueError):
-        BetaTCVAE(10, 32, 64, 16, 4, 2, 0, torch.device("cpu"))
+def test_latent_dim_independent_of_embedding_dim():
+    # The latent is projected back to model width, so it can be a true
+    # bottleneck (smaller than the embedding) without raising.
+    model = BetaTCVAE(10, 32, 64, 8, 4, 2, 0, torch.device("cpu"))
+    out, mu, log_var = model(torch.randint(0, 10, (2, 6)))
+    assert out.shape == (2, 6, 10)
+    assert mu.shape == (2, 8)


### PR DESCRIPTION
## Summary

Follow-up to #59. The VAE used a **per-position** latent (`mu`/`log_var` of shape `(batch, seq, latent)`), so a molecule was a *sequence* of latents rather than a single point — an awkward fit for "sample near a molecule" / "interpolate between two molecules". It also forced `latent_dim == embedding_dim` and kept a decoder cross-attention memory whose padding mask was handled inconsistently between `generate` (passed `memory_pad_mask`) and `interpolate` (didn't).

This reworks it into a **classic sentence VAE**: one fixed-size latent vector per molecule. That both matches what latent-space exploration actually wants and removes the pad-mask inconsistency by construction.

## Changes

- **`encode(x)`** masked-mean-pools the encoder states to a single vector → returns `(mu, log_var)` of shape `(batch, latent_dim)`.
- **`decode(z, seq_len)`** projects the latent back to model width, broadcasts it across positions, adds positional encodings, and predicts all tokens with a self-attention stack. No encoder memory ⇒ no `memory_pad_mask` ⇒ generate/interpolate are now consistent.
- `latent_dim` is independent of `embedding_dim` (a genuine bottleneck); `vae-train` gains `--latent-dim` (default 32).
- `generate.py` / `interpolate.py` updated to the new `encode`/`decode` API.
- Tests updated: `mu`/`log_var` are `(batch, latent)`; the old `latent_dim == embedding_dim` guard test is replaced by one asserting a smaller latent is allowed.

## Verification (local, CPU)

- `pytest`: **72 passed**; `ruff check` clean.
- End-to-end: `vae-train` (latent 32 / embedding 64) → `vae-sample` around `BrCC1CCCCC1` and `vae-interpolate` both produce valid, distinct molecules.