### PR TITLE
Implement a genuine total-correlation term in BetaTCVAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Changed
+- `BetaTCVAE` now optimizes a **genuine β-TC-VAE objective**: the KL term is
+  decomposed into index-code mutual information, **total correlation**, and the
+  dimension-wise KL (Chen et al., 2018), estimated with minibatch stratified
+  sampling. `beta` now scales the real total-correlation term `KL[q(z) ||
+  prod_j q(z_j)]` instead of the earlier closed-form proxy that was a function
+  of the posterior variance only. `forward` returns `(logits, mu, log_var, z)`;
+  `vae-train` gains an `--alpha` flag (defaults: `alpha=1`, `beta=4`, `gamma=1`).
 - `BetaTCVAE` is now a **sentence VAE**: a molecule is encoded to a single
   fixed-size latent vector (masked mean-pool of the encoder states) rather than
   a per-position latent, so each molecule is one point in latent space — the

--- a/molgen/cli.py
+++ b/molgen/cli.py
@@ -132,7 +132,9 @@ def cmd_vae_train(args: argparse.Namespace) -> None:
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
     loader = DataLoader(TensorDataset(data), batch_size=args.batch_size, shuffle=True)
     for epoch in range(args.epochs):
-        loss = train(model, loader, optimizer, device, beta=args.beta, gamma=args.gamma)
+        loss = train(
+            model, loader, optimizer, device, beta=args.beta, gamma=args.gamma, alpha=args.alpha
+        )
         print(f"Epoch {epoch + 1}/{args.epochs}: loss={loss:.4f}")
     save_checkpoint(args.out, model, "vae", kwargs, tokenizer)
     print(f"Saved checkpoint to {args.out}")
@@ -236,8 +238,13 @@ def build_parser() -> argparse.ArgumentParser:
     vae_train.add_argument("--hidden-dim", type=int, default=256)
     vae_train.add_argument("--num-layers", type=int, default=2)
     vae_train.add_argument("--nhead", type=int, default=4)
-    vae_train.add_argument("--beta", type=float, default=0.5)
-    vae_train.add_argument("--gamma", type=float, default=0.1)
+    vae_train.add_argument(
+        "--beta", type=float, default=4.0, help="total-correlation weight (disentanglement)"
+    )
+    vae_train.add_argument("--gamma", type=float, default=1.0, help="dimension-wise KL weight")
+    vae_train.add_argument(
+        "--alpha", type=float, default=1.0, help="index-code mutual-information weight"
+    )
     vae_train.add_argument("--seed", type=int, default=42)
     vae_train.add_argument("--out", default="vae_model.pt")
     vae_train.set_defaults(func=cmd_vae_train)

--- a/molgen/vae.py
+++ b/molgen/vae.py
@@ -7,6 +7,14 @@ models, it supports *latent-space* operations — sampling molecules near a seed
 and interpolating between two molecules — see :mod:`molgen.generate` and
 :mod:`molgen.interpolate`.
 
+The objective is a genuine **β-TC-VAE** (Chen et al., 2018, "Isolating Sources
+of Disentanglement in VAEs"): the KL term is decomposed into the index-code
+mutual information, the **total correlation**, and the dimension-wise KL, each
+separately weighted (``alpha``, ``beta``, ``gamma``). The total correlation —
+the term ``beta`` scales to encourage disentangled latents — is estimated from
+the minibatch with the paper's minibatch-stratified-sampling estimator, so it is
+the real ``KL[q(z) || prod_j q(z_j)]`` rather than a closed-form proxy.
+
 Tokenization goes through the shared toolkit tokenizers
 (:class:`molgen.selfies_tokenizer.SelfiesTokenizer` is recommended, since its
 decoder always yields a syntactically valid molecule).
@@ -23,6 +31,8 @@ import torch.nn.functional as F
 __all__ = [
     "PositionalEncoding",
     "BetaTCVAE",
+    "gaussian_log_density",
+    "kl_decomposition",
     "loss_function",
     "masked_token_accuracy",
     "train",
@@ -118,19 +128,85 @@ class BetaTCVAE(nn.Module):
         return self.fc_out(self.decoder(hidden))
 
     def forward(self, x):
+        """Return ``(logits, mu, log_var, z)`` — ``z`` is the sampled latent the
+        loss needs for its minibatch total-correlation estimate."""
         mu, log_var = self.encode(x)
         z = self.reparameterize(mu, log_var)
-        return self.decode(z, x.size(1)), mu, log_var
+        return self.decode(z, x.size(1)), mu, log_var, z
 
 
-def loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=-100):
+def gaussian_log_density(z, mu, log_var):
+    """Element-wise ``log N(z; mu, exp(log_var))`` (broadcasts over its inputs)."""
+    return -0.5 * (math.log(2 * math.pi) + log_var + (z - mu) ** 2 * torch.exp(-log_var))
+
+
+def _log_importance_weight_matrix(batch_size, dataset_size, device):
+    """Minibatch-stratified-sampling weights (Chen et al., 2018, appendix C.1).
+
+    Returns a ``(batch, batch)`` log-weight matrix that de-biases the aggregate
+    posterior estimate so the individual total-correlation / dim-wise-KL terms
+    are accurate (plain minibatch weighting biases them by ``(D-1) log M``).
+    """
+    n = dataset_size
+    m = batch_size - 1
+    strat_weight = (n - m) / (n * m)
+    weight = torch.full((batch_size, batch_size), 1 / m, device=device)
+    weight.view(-1)[:: m + 1] = 1 / n
+    weight.view(-1)[1 :: m + 1] = strat_weight
+    weight[m - 1, 0] = strat_weight
+    return weight.log()
+
+
+def kl_decomposition(z, mu, log_var, dataset_size=None):
+    """Decompose the KL into (mutual information, total correlation, dim-wise KL).
+
+    Estimates the aggregate posterior ``q(z)`` and its marginal product
+    ``prod_j q(z_j)`` from the minibatch (Chen et al., 2018, "Isolating Sources
+    of Disentanglement in VAEs"). With ``dataset_size`` (``N``) and a batch of at
+    least two molecules this uses **minibatch stratified sampling**, whose
+    importance weights de-bias the individual terms; otherwise it falls back to
+    the plain minibatch weight ``log(1 / M)``.
+
+    Returns three scalar tensors ``(mutual_info, total_correlation, dim_kl)``
+    whose sum equals the Monte-Carlo ``KL[q(z|x) || N(0, I)]`` on the same ``z``.
+    """
+    batch_size = z.size(0)
+
+    log_qz_x = gaussian_log_density(z, mu, log_var).sum(dim=1)  # (M,)
+    log_pz = gaussian_log_density(z, torch.zeros_like(z), torch.zeros_like(z)).sum(dim=1)  # (M,)
+
+    # Pairwise per-dim densities log q(z_i | x_j): (M, M, D).
+    mat = gaussian_log_density(z.unsqueeze(1), mu.unsqueeze(0), log_var.unsqueeze(0))
+
+    if dataset_size and dataset_size > batch_size and batch_size > 1:
+        logiw = _log_importance_weight_matrix(batch_size, dataset_size, z.device)  # (M, M)
+        log_qz = torch.logsumexp(logiw + mat.sum(dim=2), dim=1)  # (M,)
+        log_qz_prod = torch.logsumexp(logiw.unsqueeze(-1) + mat, dim=1).sum(dim=1)  # (M,)
+    else:
+        log_norm = math.log(batch_size)
+        log_qz = torch.logsumexp(mat.sum(dim=2), dim=1) - log_norm
+        log_qz_prod = (torch.logsumexp(mat, dim=1) - log_norm).sum(dim=1)
+
+    mutual_info = (log_qz_x - log_qz).mean()
+    total_correlation = (log_qz - log_qz_prod).mean()
+    dim_kl = (log_qz_prod - log_pz).mean()
+    return mutual_info, total_correlation, dim_kl
+
+
+def loss_function(
+    recon_x, x, mu, log_var, z, beta=1.0, gamma=1.0, alpha=1.0, dataset_size=None, pad_idx=-100
+):
+    """β-TC-VAE loss: reconstruction + ``alpha*MI + beta*TC + gamma*dim_kl``.
+
+    ``beta`` weights the **total correlation** (the disentanglement knob);
+    ``alpha`` the index-code mutual information; ``gamma`` the dimension-wise KL.
+    With ``alpha == beta == gamma`` the penalty reduces to the plain VAE KL.
+    """
     BCE = F.cross_entropy(
         recon_x.view(-1, recon_x.size(-1)), x.view(-1), ignore_index=pad_idx, reduction="mean"
     )
-    KLD = -0.5 * torch.mean(1 + log_var - mu.pow(2) - log_var.exp())
-    TC = (log_var.exp() - 1 - log_var).mean()
-
-    return BCE + beta * KLD + gamma * TC
+    mutual_info, total_correlation, dim_kl = kl_decomposition(z, mu, log_var, dataset_size)
+    return BCE + alpha * mutual_info + beta * total_correlation + gamma * dim_kl
 
 
 def masked_token_accuracy(preds, targets, pad_idx):
@@ -144,15 +220,34 @@ def masked_token_accuracy(preds, targets, pad_idx):
     return correct, total
 
 
-def train(model, train_loader, optimizer, device, beta, gamma):
+def _dataset_size(loader):
+    try:
+        return len(loader.dataset)
+    except (AttributeError, TypeError):
+        return None
+
+
+def train(model, train_loader, optimizer, device, beta, gamma, alpha=1.0):
     model.train()
     total_loss = 0.0
+    dataset_size = _dataset_size(train_loader)
 
     for batch in train_loader:
         x = (batch[0] if isinstance(batch, (list, tuple)) else batch).to(device)
         optimizer.zero_grad()
-        recon_x, mu, log_var = model(x)
-        loss = loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=model.pad_idx)
+        recon_x, mu, log_var, z = model(x)
+        loss = loss_function(
+            recon_x,
+            x,
+            mu,
+            log_var,
+            z,
+            beta=beta,
+            gamma=gamma,
+            alpha=alpha,
+            dataset_size=dataset_size,
+            pad_idx=model.pad_idx,
+        )
         loss.backward()
         optimizer.step()
         total_loss += loss.item()
@@ -160,17 +255,29 @@ def train(model, train_loader, optimizer, device, beta, gamma):
     return total_loss / len(train_loader)
 
 
-def test(model, test_loader, device, beta, gamma):
+def test(model, test_loader, device, beta, gamma, alpha=1.0):
     model.eval()
     total_loss = 0.0
     correct = 0
     total = 0
+    dataset_size = _dataset_size(test_loader)
 
     with torch.no_grad():
         for batch in test_loader:
             x = (batch[0] if isinstance(batch, (list, tuple)) else batch).to(device)
-            recon_x, mu, log_var = model(x)
-            loss = loss_function(recon_x, x, mu, log_var, beta, gamma, pad_idx=model.pad_idx)
+            recon_x, mu, log_var, z = model(x)
+            loss = loss_function(
+                recon_x,
+                x,
+                mu,
+                log_var,
+                z,
+                beta=beta,
+                gamma=gamma,
+                alpha=alpha,
+                dataset_size=dataset_size,
+                pad_idx=model.pad_idx,
+            )
             total_loss += loss.item()
 
             preds = torch.argmax(recon_x, dim=-1)
@@ -210,8 +317,10 @@ def main():
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     loader = DataLoader(TensorDataset(data), batch_size=64, shuffle=True)
 
+    # beta>1 up-weights the total-correlation term (disentanglement); alpha and
+    # gamma keep the mutual-information and dimension-wise-KL terms at 1.0.
     for epoch in range(10):
-        loss = train(model, loader, optimizer, device, beta=0.5, gamma=0.1)
+        loss = train(model, loader, optimizer, device, beta=4.0, gamma=1.0, alpha=1.0)
         print(f"Epoch {epoch + 1}: loss={loss:.4f}")
 
     save_checkpoint("vae_model.pt", model, "vae", model_kwargs, tokenizer)

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -1,8 +1,17 @@
 """Tests for the BetaTCVAE model and loss."""
 
+import math
+
 import torch
 
-from molgen.vae import BetaTCVAE, PositionalEncoding, loss_function, masked_token_accuracy
+from molgen.vae import (
+    BetaTCVAE,
+    PositionalEncoding,
+    gaussian_log_density,
+    kl_decomposition,
+    loss_function,
+    masked_token_accuracy,
+)
 
 
 def _tiny_model():
@@ -22,18 +31,19 @@ def test_forward_output_shapes():
     model = _tiny_model()
     batch, seq = 4, 12
     x = torch.randint(0, 6, (batch, seq))
-    out, mu, log_var = model(x)
+    out, mu, log_var, z = model(x)
     assert out.shape == (batch, seq, 6)
     # One fixed-size latent vector per molecule (not per position).
     assert mu.shape == (batch, 16)
     assert log_var.shape == (batch, 16)
+    assert z.shape == (batch, 16)
 
 
 def test_loss_is_finite_scalar():
     model = _tiny_model()
     x = torch.randint(0, 6, (4, 12))
-    out, mu, log_var = model(x)
-    loss = loss_function(out, x, mu, log_var, beta=1.0, gamma=0.1)
+    out, mu, log_var, z = model(x)
+    loss = loss_function(out, x, mu, log_var, z, beta=4.0, gamma=1.0)
     assert loss.dim() == 0
     assert torch.isfinite(loss)
 
@@ -41,8 +51,8 @@ def test_loss_is_finite_scalar():
 def test_backward_pass_populates_gradients():
     model = _tiny_model()
     x = torch.randint(0, 6, (2, 8))
-    out, mu, log_var = model(x)
-    loss = loss_function(out, x, mu, log_var, beta=1.0, gamma=0.1)
+    out, mu, log_var, z = model(x)
+    loss = loss_function(out, x, mu, log_var, z, beta=4.0, gamma=1.0)
     loss.backward()
     grads = [p.grad for p in model.parameters() if p.requires_grad]
     assert any(g is not None and torch.isfinite(g).all() for g in grads)
@@ -53,20 +63,70 @@ def test_loss_ignores_pad_positions():
     x = torch.tensor([[0, 1, 4, 4, 4]])
     mu = torch.zeros(1, 4)
     log_var = torch.zeros(1, 4)
+    z = torch.zeros(1, 4)  # same latent for both, so only BCE can differ
     recon_a = torch.randn(1, 5, 6)
     recon_b = recon_a.clone()
     # Change the logits only at the padding positions.
     recon_b[:, 2:, :] = torch.randn(1, 3, 6)
 
     # With masking, padding positions are ignored, so the loss is unchanged.
-    loss_a = loss_function(recon_a, x, mu, log_var, beta=1.0, gamma=0.1, pad_idx=4)
-    loss_b = loss_function(recon_b, x, mu, log_var, beta=1.0, gamma=0.1, pad_idx=4)
+    loss_a = loss_function(recon_a, x, mu, log_var, z, beta=1.0, gamma=1.0, pad_idx=4)
+    loss_b = loss_function(recon_b, x, mu, log_var, z, beta=1.0, gamma=1.0, pad_idx=4)
     assert torch.allclose(loss_a, loss_b)
 
     # Without masking (default ignore_index), those positions do count.
-    loss_a_unmasked = loss_function(recon_a, x, mu, log_var, beta=1.0, gamma=0.1)
-    loss_b_unmasked = loss_function(recon_b, x, mu, log_var, beta=1.0, gamma=0.1)
+    loss_a_unmasked = loss_function(recon_a, x, mu, log_var, z, beta=1.0, gamma=1.0)
+    loss_b_unmasked = loss_function(recon_b, x, mu, log_var, z, beta=1.0, gamma=1.0)
     assert not torch.allclose(loss_a_unmasked, loss_b_unmasked)
+
+
+def test_kl_decomposition_sums_to_total_kl():
+    # The three estimated terms (MI + TC + dim-wise KL) must sum to the plain
+    # Monte-Carlo KL[q(z|x) || p(z)] = E[log q(z|x) - log p(z)] on the same z.
+    torch.manual_seed(0)
+    mu = torch.randn(32, 8)
+    log_var = torch.randn(32, 8) * 0.5
+    z = mu + torch.randn_like(mu) * torch.exp(0.5 * log_var)
+
+    mi, tc, dim_kl = kl_decomposition(z, mu, log_var, dataset_size=10000)
+
+    log_qz_x = gaussian_log_density(z, mu, log_var).sum(dim=1)
+    log_pz = gaussian_log_density(z, torch.zeros_like(z), torch.zeros_like(z)).sum(dim=1)
+    mc_kl = (log_qz_x - log_pz).mean()
+
+    assert torch.isclose(mi + tc + dim_kl, mc_kl, atol=1e-4)
+
+
+def test_total_correlation_detects_dependence():
+    # The stratified estimator should report ~0 total correlation when the
+    # aggregate posterior factorizes, and clearly positive TC when two latent
+    # dimensions are tied — the property that makes it a *real* TC term rather
+    # than the old closed-form proxy.
+    torch.manual_seed(0)
+
+    # Independent posteriors -> aggregate posterior factorizes -> TC ~ 0.
+    mu = torch.zeros(256, 6)
+    log_var = torch.zeros(256, 6)
+    z = torch.randn(256, 6)
+    _, tc_indep, _ = kl_decomposition(z, mu, log_var, dataset_size=10000)
+    assert abs(tc_indep.item()) < 0.5
+
+    # Tie dims 0 and 1 across the batch (correlated means) -> TC clearly > 0.
+    shared = torch.randn(256, 1) * 2
+    mu_corr = torch.cat([shared, shared, torch.randn(256, 4) * 2], dim=1)
+    log_var_corr = torch.full((256, 6), -2.0)
+    z_corr = mu_corr + torch.randn_like(mu_corr) * torch.exp(0.5 * log_var_corr)
+    _, tc_corr, _ = kl_decomposition(z_corr, mu_corr, log_var_corr, dataset_size=10000)
+    assert tc_corr.item() > 1.0
+    assert tc_corr.item() > tc_indep.item() + 1.0
+
+
+def test_gaussian_log_density_matches_closed_form():
+    z = torch.tensor([[0.5, -1.0]])
+    mu = torch.tensor([[0.0, 0.0]])
+    log_var = torch.zeros(1, 2)  # unit variance
+    expected = -0.5 * (math.log(2 * math.pi) + z**2)  # standard normal log-pdf
+    assert torch.allclose(gaussian_log_density(z, mu, log_var), expected, atol=1e-6)
 
 
 def test_masked_token_accuracy_excludes_padding():
@@ -109,6 +169,7 @@ def test_latent_dim_independent_of_embedding_dim():
     # The latent is projected back to model width, so it can be a true
     # bottleneck (smaller than the embedding) without raising.
     model = BetaTCVAE(10, 32, 64, 8, 4, 2, 0, torch.device("cpu"))
-    out, mu, log_var = model(torch.randint(0, 10, (2, 6)))
+    out, mu, log_var, z = model(torch.randint(0, 10, (2, 6)))
     assert out.shape == (2, 6, 10)
     assert mu.shape == (2, 8)
+    assert z.shape == (2, 8)


### PR DESCRIPTION
`BetaTCVAE`'s loss previously computed `TC = (var - 1 - log_var).mean()` — a closed-form function of the posterior variance, **not** the total correlation. It is perfectly correlated with the variance part of the KL that `KLD` already contains, so despite the `BetaTCVAE` name the model was a plain β-VAE with an extra variance penalty. A reviewer reading the code would catch the mismatch.

This PR makes the name accurate by implementing the real β-TC-VAE objective (Chen et al., 2018, *Isolating Sources of Disentanglement in VAEs*):

- the KL decomposes into **index-code mutual information + total correlation + dimension-wise KL**, each separately weighted (`alpha`, `beta`, `gamma`); `beta` now scales the genuine `KL[q(z) || prod_j q(z_j)]`
- `q(z)` and `prod_j q(z_j)` are estimated from the minibatch with **stratified-sampling importance weights**; plain minibatch weighting biases the individual terms by `(D-1)·log M` (I verified this empirically — it inflated TC to ~28 nats on independent latents), MSS removes it
- `forward` now returns `(logits, mu, log_var, z)`; `train`/`test`/`vae-train` thread `z` and the dataset size through; `vae-train` gains `--alpha` (defaults α=1, β=4, γ=1)

**Tests** (new): the three terms sum to the Monte-Carlo `KL[q(z|x)||N(0,I)]` (telescoping identity, holds for any estimator); TC ≈ 0 for independent latents and clearly positive when two dims are tied; `gaussian_log_density` matches the standard-normal closed form. Full suite 75 passed, ruff clean.

**Validated on an RTX 4080**: training converges (loss 2.08 → 1.81 over 10 epochs on the bundled sample) and both latent-space demos (`python -m molgen.generate` / `molgen.interpolate`) still produce valid, distinct molecules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)