### PR TITLE
Lead Installation with 'pip install molgen' now that it is on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,16 @@ GPU in minutes, but reflecting current practice.
 ## Installation
 
 ```bash
+pip install molgen              # from PyPI
+pip install "molgen[selfies]"   # + SELFIES (always-valid decoding)
+```
+
+From source (for development / running the tests):
+
+```bash
 git clone https://github.com/DaoyuanLi2816/molgen.git
 cd molgen
-pip install -e .            # add ".[selfies]" for SELFIES, ".[dev]" for tests
+pip install -e ".[selfies,dev]"
 ```
 
 ## Quickstart (Python)


### PR DESCRIPTION
The package has been published on PyPI since 0.1.0 (and the banner already shows `pip install molgen`), but the Installation section still led with a `git clone` + `pip install -e .`. This updates it to:

- **`pip install molgen`** / `pip install "molgen[selfies]"` as the primary path
- the from-source clone kept below for development (`-e ".[selfies,dev]"`)

While here I re-ran the README's Python quickstart against the current API end to end (train → sample → evaluate) to confirm it isn't stale after the recent refactors — it runs and the `build_dataloaders` / `train_language_model` signatures match. No other drift found (models table, CLI flags, and VAE commands all match the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)